### PR TITLE
Rename #[register] to #[register_map] and #[entry] to #[register]

### DIFF
--- a/cameleon-device/examples/usb3/device_control.rs
+++ b/cameleon-device/examples/usb3/device_control.rs
@@ -32,7 +32,7 @@ fn main() {
     // Open the channel to allow communication with the device.
     control_channel.open().unwrap();
 
-    // Get address and length of serial number entry in ABRM.
+    // Get address and length of serial number register in ABRM.
     let (addr, len) = register_map::abrm::SERIAL_NUMBER;
 
     // Create ReadMem Command with request id.

--- a/cameleon-device/src/usb3/emulator/emulator_impl/emulator_builder.rs
+++ b/cameleon-device/src/usb3/emulator/emulator_impl/emulator_builder.rs
@@ -63,9 +63,7 @@ impl EmulatorBuilder {
         let serial_number: String = (0..8)
             .map(|_| serial_base.choose(&mut rang).unwrap())
             .collect();
-        memory
-            .write_entry::<ABRM::SerialNumber>(serial_number)
-            .unwrap();
+        memory.write::<ABRM::SerialNumber>(serial_number).unwrap();
 
         Self { memory }
     }
@@ -119,7 +117,7 @@ impl EmulatorBuilder {
     /// ```
     pub fn model_name(mut self, name: &str) -> BuilderResult<Self> {
         self.memory
-            .write_entry::<ABRM::UserDefinedName>(name.into())
+            .write::<ABRM::UserDefinedName>(name.into())
             .map_err(|e| BuilderError::InvalidString(format! {"{}", e}))?;
         Ok(self)
     }
@@ -145,7 +143,7 @@ impl EmulatorBuilder {
     /// ```
     pub fn family_name(mut self, name: &str) -> BuilderResult<Self> {
         self.memory
-            .write_entry::<ABRM::UserDefinedName>(name.into())
+            .write::<ABRM::UserDefinedName>(name.into())
             .map_err(|e| BuilderError::InvalidString(format! {"{}", e}))?;
         Ok(self)
     }
@@ -171,7 +169,7 @@ impl EmulatorBuilder {
     /// ```
     pub fn serial_number(mut self, serial: &str) -> BuilderResult<Self> {
         self.memory
-            .write_entry::<ABRM::UserDefinedName>(serial.into())
+            .write::<ABRM::UserDefinedName>(serial.into())
             .map_err(|e| BuilderError::InvalidString(format! {"{}", e}))?;
         Ok(self)
     }
@@ -197,25 +195,25 @@ impl EmulatorBuilder {
     /// ```
     pub fn user_defined_name(mut self, name: &str) -> BuilderResult<Self> {
         self.memory
-            .write_entry::<ABRM::UserDefinedName>(name.into())
+            .write::<ABRM::UserDefinedName>(name.into())
             .map_err(|e| BuilderError::InvalidString(format! {"{}", e}))?;
         Ok(self)
     }
 
     fn build_device_info(&self) -> DeviceInfo {
         use ABRM::*;
-        let gencp_version_major = self.memory.read_entry::<GenCpVersionMajor>().unwrap();
-        let gencp_version_minor = self.memory.read_entry::<GenCpVersionMinor>().unwrap();
+        let gencp_version_major = self.memory.read::<GenCpVersionMajor>().unwrap();
+        let gencp_version_minor = self.memory.read::<GenCpVersionMinor>().unwrap();
         let gencp_version = Version::new(gencp_version_major as u64, gencp_version_minor as u64, 0);
 
-        let vendor_name = self.memory.read_entry::<ManufacturerName>().unwrap();
-        let model_name = self.memory.read_entry::<ModelName>().unwrap();
-        let family_name = Some(self.memory.read_entry::<FamilyName>().unwrap());
-        let device_version = self.memory.read_entry::<DeviceVersion>().unwrap();
-        let manufacturer_info = self.memory.read_entry::<ManufacturerInfo>().unwrap();
-        let user_defined_name = Some(self.memory.read_entry::<UserDefinedName>().unwrap());
+        let vendor_name = self.memory.read::<ManufacturerName>().unwrap();
+        let model_name = self.memory.read::<ModelName>().unwrap();
+        let family_name = Some(self.memory.read::<FamilyName>().unwrap());
+        let device_version = self.memory.read::<DeviceVersion>().unwrap();
+        let manufacturer_info = self.memory.read::<ManufacturerInfo>().unwrap();
+        let user_defined_name = Some(self.memory.read::<UserDefinedName>().unwrap());
         let supported_speed = SupportedSpeed::SuperSpeed;
-        let serial_number = self.memory.read_entry::<SerialNumber>().unwrap();
+        let serial_number = self.memory.read::<SerialNumber>().unwrap();
 
         // TODO: Read from SBRM.
         let u3v_version = Version::new(1, 0, 0);

--- a/cameleon-device/src/usb3/emulator/emulator_impl/memory.rs
+++ b/cameleon-device/src/usb3/emulator/emulator_impl/memory.rs
@@ -1,4 +1,4 @@
-use cameleon_impl::memory::{memory, register};
+use cameleon_impl::memory::{memory, register_map};
 
 const SBRM_ADDRESS: u64 = 0xffff;
 
@@ -26,74 +26,74 @@ pub(super) struct Memory {
     abrm: ABRM,
 }
 
-#[register(base = 0, endianness = LE)]
+#[register_map(base = 0, endianness = LE)]
 pub(super) enum ABRM {
-    #[entry(len = 2, access = RO, ty = u16)]
+    #[register(len = 2, access = RO, ty = u16)]
     GenCpVersionMinor = 1,
 
-    #[entry(len = 2, access = RO, ty = u16)]
+    #[register(len = 2, access = RO, ty = u16)]
     GenCpVersionMajor = 1,
 
-    #[entry(len = 64, access = RO, ty = String)]
+    #[register(len = 64, access = RO, ty = String)]
     ManufacturerName = "cameleon",
 
-    #[entry(len = 64, access = RO, ty = String)]
+    #[register(len = 64, access = RO, ty = String)]
     ModelName = "cameleon model",
 
-    #[entry(len = 64, access = RO, ty = String)]
+    #[register(len = 64, access = RO, ty = String)]
     FamilyName = "cameleon family",
 
-    #[entry(len = 64, access = RO, ty = String)]
+    #[register(len = 64, access = RO, ty = String)]
     DeviceVersion = "none",
 
-    #[entry(len = 64, access = RO, ty = String)]
+    #[register(len = 64, access = RO, ty = String)]
     ManufacturerInfo = "none",
 
-    #[entry(len = 64, access = RO, ty = String)]
+    #[register(len = 64, access = RO, ty = String)]
     SerialNumber,
 
-    #[entry(len = 64, access = RW, ty = String)]
+    #[register(len = 64, access = RW, ty = String)]
     UserDefinedName,
 
-    #[entry(len = 8, access = RO, ty = Bytes)]
+    #[register(len = 8, access = RO, ty = Bytes)]
     DeviceCapability = DEVICE_CAPABILITY,
 
-    #[entry(len = 4, access = RO, ty = u32)]
+    #[register(len = 4, access = RO, ty = u32)]
     MaximumDeviceResponseTime = 100,
 
-    #[entry(len = 8, access = RO, ty = u64)]
+    #[register(len = 8, access = RO, ty = u64)]
     ManifestTableAddress, // TODO: Define manifest table address,
 
-    #[entry(len = 8, access = RO, ty = u64)]
+    #[register(len = 8, access = RO, ty = u64)]
     SBRMAddress = SBRM_ADDRESS,
 
-    #[entry(len = 8, access = RO, ty = u64)]
+    #[register(len = 8, access = RO, ty = u64)]
     DeviceConfiguration,
 
-    #[entry(len = 4, access = NA, ty = u32)]
+    #[register(len = 4, access = NA, ty = u32)]
     HeartbeatTimeout,
 
-    #[entry(len = 4, access = NA, ty = u32)]
+    #[register(len = 4, access = NA, ty = u32)]
     MessageChannelId,
 
-    #[entry(len = 8, access = RO, ty = u64)]
+    #[register(len = 8, access = RO, ty = u64)]
     Timestamp,
 
-    #[entry(len = 4, access = WO, ty = u32)]
+    #[register(len = 4, access = WO, ty = u32)]
     TimestampLatch,
 
-    #[entry(len = 8, access = RO, ty = u64)]
+    #[register(len = 8, access = RO, ty = u64)]
     TimestampIncrement = 1000, // Dummy value indicating device clock runs at 1MHZ.
 
-    #[entry(len = 4, access = NA, ty = Bytes)]
+    #[register(len = 4, access = NA, ty = Bytes)]
     AccessPrivilege,
 
-    #[entry(len = 4, access = RO, ty = Bytes)]
+    #[register(len = 4, access = RO, ty = Bytes)]
     ProtocolEndianness = &[0xFF, 0xFF, 0xFF, 0xFF], // Little endian.
 
-    #[entry(len = 4, access = NA, ty = Bytes)]
+    #[register(len = 4, access = NA, ty = Bytes)]
     ImplementationEndianness,
 
-    #[entry(len = 64, access = RO, ty = String)]
+    #[register(len = 64, access = RO, ty = String)]
     DeviceSoftwareInterfaceVersion = "1.0.0",
 }

--- a/cameleon-device/src/usb3/protocol/ack.rs
+++ b/cameleon-device/src/usb3/protocol/ack.rs
@@ -366,8 +366,7 @@ impl<'a> ParseScd<'a> for WriteMemStacked {
             let reserved = cursor.read_u16::<LE>()?;
             if reserved != 0 {
                 return Err(Error::InvalidPacket(
-                    "the first two bytes of each WriteMemStackedAck scd entry must be set to zero"
-                        .into(),
+                    "the first two bytes of each WriteMemStackedAck SCD must be set to zero".into(),
                 ));
             }
             let length = cursor.read_u16::<LE>()?;

--- a/cameleon-device/src/usb3/protocol/cmd.rs
+++ b/cameleon-device/src/usb3/protocol/cmd.rs
@@ -129,10 +129,8 @@ impl ReadMemStacked {
         CommandPacket::new(self, request_id)
     }
 
-    fn len(entries: &[ReadMem]) -> Result<u16> {
-        let len = entries
-            .iter()
-            .fold(0, |acc, ent| acc + ent.scd_len() as usize);
+    fn len(regs: &[ReadMem]) -> Result<u16> {
+        let len = regs.iter().fold(0, |acc, reg| acc + reg.scd_len() as usize);
         into_scd_len(len)
     }
 
@@ -173,7 +171,7 @@ impl<'a> WriteMemStacked<'a> {
     fn len(entries: &[WriteMem<'a>]) -> Result<u16> {
         let len = entries
             .iter()
-            .fold(0, |acc, ent| acc + 12 + ent.data_len as usize);
+            .fold(0, |acc, cmd| acc + 12 + cmd.data_len as usize);
         into_scd_len(len)
     }
 }
@@ -366,7 +364,7 @@ impl<'a> CommandScd for WriteMemStacked<'a> {
     }
 
     fn scd_len(&self) -> u16 {
-        // Each entry is composed of [address(8bytes), reserved(2bytes), data_len(2bytes), data(len bytes)]
+        // Each register is composed of [address(8bytes), reserved(2bytes), data_len(2bytes), data(len bytes)]
         self.len
     }
 

--- a/cameleon-device/src/usb3/register_map.rs
+++ b/cameleon-device/src/usb3/register_map.rs
@@ -1,4 +1,4 @@
-/// (Address, Length, Access Right) of all entries in Technology Agnostic Boot Register Map (ABRM).
+/// (Address, Length, Access Right) of registers in Technology Agnostic Boot Register Map (ABRM).
 pub mod abrm {
     pub const GENCP_VERSION: (u64, u16) = (0x0000, 4);
     pub const MANUFACTURER_NAME: (u64, u16) = (0x0004, 64);
@@ -24,7 +24,7 @@ pub mod abrm {
     pub const DEVICE_SOFTWARE_INTERFACE_VERSION: (u64, u16) = (0x0210, 64);
 }
 
-/// (Offset, Length, Access Right) of entries in Technology Specific Boot Register Map (SBRM).
+/// (Offset, Length, Access Right) of registers in Technology Specific Boot Register Map (SBRM).
 /// SBRM base address can be obtained by reading `abrm::SBRM_ADDRESS`.
 pub mod sbrm {
     pub const U3V_VERSION: (u64, u16) = (0x0000, 4);
@@ -41,7 +41,7 @@ pub mod sbrm {
     pub const CURRENT_SPEED: (u64, u16) = (0x040, 4);
 }
 
-/// (Offset, Length, Access Right) of all entries in Event Interface Register Map (EIRM).
+/// (Offset, Length, Access Right) of registers in Event Interface Register Map (EIRM).
 /// SIRM base address can be obtained by
 /// sbrm::EIRM_ADDRESS.
 pub mod eirm {
@@ -50,7 +50,7 @@ pub mod eirm {
     pub const EVENT_TEST_CONTROL: (u64, u16) = (0x0008, 4);
 }
 
-/// (Offset, Length) of all entries in Streaming Interface Register Map (SIRM).
+/// (Offset, Length) of registers in Streaming Interface Register Map (SIRM).
 /// SIRM base address can be obtained by
 /// `sbrm::SIRM_ADDRESS`.
 pub mod sirm {

--- a/cameleon-device/tests/normal_scenario.rs
+++ b/cameleon-device/tests/normal_scenario.rs
@@ -32,8 +32,8 @@ fn test_normal_scenario() {
 
     let mut req_id = 0;
 
-    // Send WriteMem command to time stamp latch entry of the device.
-    // The command will dispatch a internal event which cause write to time stamp entry of the
+    // Send WriteMem command to time stamp latch register of the device.
+    // The command will dispatch a internal event which cause write to time stamp register of the
     // device.
     let (tsl_addr, _) = register_map::abrm::TIMESTAMP_LATCH;
     let cmd_data = u32_as_le_bytes(1);
@@ -53,7 +53,7 @@ fn test_normal_scenario() {
     // Increment req_id for next command.
     req_id += 1;
 
-    // Send ReadMem command to time stamp entry.
+    // Send ReadMem command to time stamp register.
     let (ts_addr, ts_len) = register_map::abrm::TIMESTAMP;
     let (cmd, ack_len) = read_cmd(ts_addr, ts_len, req_id);
     assert!(control_channel.send(&cmd, TIME_OUT).is_ok());
@@ -75,7 +75,7 @@ fn test_normal_scenario() {
     // Increment req_id for next command.
     req_id += 1;
 
-    // Send ReadMem command to time stamp entry.
+    // Send ReadMem command to time stamp register.
     let (ts_addr, ts_len) = register_map::abrm::TIMESTAMP;
     let (cmd, _) = read_cmd(ts_addr, ts_len, req_id);
     assert!(control_channel.send(&cmd, TIME_OUT).is_ok());

--- a/cameleon-impl/macros/src/lib.rs
+++ b/cameleon-impl/macros/src/lib.rs
@@ -1,12 +1,12 @@
 mod memory;
-mod register;
+mod register_map;
 
 #[proc_macro_attribute]
-pub fn register(
+pub fn register_map(
     args: proc_macro::TokenStream,
     input: proc_macro::TokenStream,
 ) -> proc_macro::TokenStream {
-    match register::expand(args, input) {
+    match register_map::expand(args, input) {
         Ok(ts) => ts,
         Err(e) => e.to_compile_error().into(),
     }

--- a/cameleon-impl/tests/macros/forbidden_visibility.rs
+++ b/cameleon-impl/tests/macros/forbidden_visibility.rs
@@ -2,20 +2,20 @@ const SBRM_ADDRESS: u64 = 0x1000;
 
 mod outer {
     pub(super) mod inner {
-        use cameleon_impl::memory::register;
+        use cameleon_impl::memory::register_map;
 
-        #[register(base = 0, endianness = LE)]
+        #[register_map(base = 0, endianness = LE)]
         pub(in super::super) enum ABRM {
-            #[entry(len = 2, access = RO, ty = u16)]
+            #[register(len = 2, access = RO, ty = u16)]
             GenCpVersionMinor = 321,
 
-            #[entry(len = 2, access = RO, ty = u16)]
+            #[register(len = 2, access = RO, ty = u16)]
             GenCpVersionMajor,
 
-            #[entry(len = 64, access = RW, ty = String)]
+            #[register(len = 64, access = RW, ty = String)]
             ManufacturerName = "Cameleon\0",
 
-            #[entry(len = 8, access = RO, ty = u64)]
+            #[register(len = 8, access = RO, ty = u64)]
             SBRMAddress = super::super::SBRM_ADDRESS,
         }
     }

--- a/cameleon-impl/tests/macros/memory.rs
+++ b/cameleon-impl/tests/macros/memory.rs
@@ -1,4 +1,4 @@
-use cameleon_impl::memory::{memory, prelude::*, register, AccessRight};
+use cameleon_impl::memory::{memory, prelude::*, register_map, AccessRight};
 
 const SBRM_ADDRESS: u64 = 0x1000;
 const SIRM_ADDRESS: u64 = 0x2000;
@@ -14,74 +14,74 @@ pub struct Memory {
     sbrm: SBRM,
 }
 
-#[register(base = 0, endianness = LE)]
+#[register_map(base = 0, endianness = LE)]
 enum ABRM {
-    #[entry(len = 2, access = RO, ty = u16)]
+    #[register(len = 2, access = RO, ty = u16)]
     GenCpVersionMinor = 321,
 
-    #[entry(len = 2, access = RO, ty = u16)]
+    #[register(len = 2, access = RO, ty = u16)]
     GenCpVersionMajor,
 
-    #[entry(len = 64, access = RW, ty = String)]
+    #[register(len = 64, access = RW, ty = String)]
     ManufacturerName = "Cameleon",
 
-    #[entry(len = 8, access = RO, ty = u64)]
+    #[register(len = 8, access = RO, ty = u64)]
     SBRMAddress = SBRM_ADDRESS,
 
-    #[entry(len = 8, access = RO, ty = Bytes)]
+    #[register(len = 8, access = RO, ty = Bytes)]
     DeviceCapability = DEVICE_CAPABILITY,
 
-    #[entry(len = 4, access = RO, ty = Bytes)]
+    #[register(len = 4, access = RO, ty = Bytes)]
     ProtocolEndianness = &[0x11, 0x22, 0x33, 0x44],
 }
 
-#[register(base = SBRM_ADDRESS, endianness = BE)]
+#[register_map(base = SBRM_ADDRESS, endianness = BE)]
 enum SBRM {
-    #[entry(len = 8, access = RO, ty = u64)]
+    #[register(len = 8, access = RO, ty = u64)]
     SIRMAddress = SIRM_ADDRESS,
 
-    #[entry(len = 4, access = RO, ty = u32)]
+    #[register(len = 4, access = RO, ty = u32)]
     SIRMLength = 0x20,
 
-    #[entry(len = 8, access = RO, ty = u64)]
+    #[register(len = 8, access = RO, ty = u64)]
     EIRMAddress = EIRM_ADDRESS,
 
-    #[entry(len = 4, access = RO, ty = u32)]
+    #[register(len = 4, access = RO, ty = u32)]
     EIRMLength = 0x20,
 }
 
 fn main() {
     let mut memory = Memory::new();
 
-    // Test read_entry.
-    let gen_cp_minor = memory.read_entry::<ABRM::GenCpVersionMinor>().unwrap();
+    // Test read.
+    let gen_cp_minor = memory.read::<ABRM::GenCpVersionMinor>().unwrap();
     assert_eq!(gen_cp_minor, 321);
 
-    let sbrm_address = memory.read_entry::<ABRM::SBRMAddress>().unwrap();
+    let sbrm_address = memory.read::<ABRM::SBRMAddress>().unwrap();
     assert_eq!(sbrm_address, SBRM_ADDRESS);
 
-    let manufacturer_name = memory.read_entry::<ABRM::ManufacturerName>().unwrap();
+    let manufacturer_name = memory.read::<ABRM::ManufacturerName>().unwrap();
     assert_eq!(&manufacturer_name, "Cameleon");
 
-    let sirm_address = memory.read_entry::<SBRM::SIRMAddress>().unwrap();
+    let sirm_address = memory.read::<SBRM::SIRMAddress>().unwrap();
     assert_eq!(sirm_address, SIRM_ADDRESS);
 
-    let device_capability = memory.read_entry::<ABRM::DeviceCapability>().unwrap();
+    let device_capability = memory.read::<ABRM::DeviceCapability>().unwrap();
     assert_eq!(device_capability.as_slice(), DEVICE_CAPABILITY);
 
-    let protocol_endianness = memory.read_entry::<ABRM::ProtocolEndianness>().unwrap();
+    let protocol_endianness = memory.read::<ABRM::ProtocolEndianness>().unwrap();
     assert_eq!(protocol_endianness.as_slice(), &[0x11, 0x22, 0x33, 0x44]);
 
-    // Test write entry.
+    // Test write.
     memory
-        .write_entry::<ABRM::ManufacturerName>("New name".into())
+        .write::<ABRM::ManufacturerName>("New name".into())
         .unwrap();
-    let manufacturer_name = memory.read_entry::<ABRM::ManufacturerName>().unwrap();
+    let manufacturer_name = memory.read::<ABRM::ManufacturerName>().unwrap();
     assert_eq!(&manufacturer_name, "New name");
 
     assert_eq!(memory.access_right::<SBRM::EIRMLength>(), AccessRight::RO);
     memory.set_access_right::<SBRM::EIRMLength>(AccessRight::NA);
     assert_eq!(memory.access_right::<SBRM::EIRMLength>(), AccessRight::NA);
 
-    assert!(memory.read(1000..1004).is_err());
+    assert!(memory.read_raw(1000..1004).is_err());
 }

--- a/cameleon-impl/tests/macros/register.rs
+++ b/cameleon-impl/tests/macros/register.rs
@@ -2,33 +2,33 @@ use cameleon_impl::memory::*;
 
 const SBRM_ADDRESS: u64 = 0x1000;
 
-#[register(base = 0, endianness = LE)]
+#[register_map(base = 0, endianness = LE)]
 pub enum ABRM {
-    #[entry(len = 2, access = RO, ty = u16)]
+    #[register(len = 2, access = RO, ty = u16)]
     GenCpVersionMinor = 321,
 
-    #[entry(len = 2, access = RO, ty = u16)]
+    #[register(len = 2, access = RO, ty = u16)]
     GenCpVersionMajor,
 
-    #[entry(len = 64, access = RW, ty = String)]
+    #[register(len = 64, access = RW, ty = String)]
     ManufacturerName = "Cameleon\0",
 
-    #[entry(len = 8, access = RO, ty = u64)]
+    #[register(len = 8, access = RO, ty = u64)]
     SBRMAddress = SBRM_ADDRESS,
 }
 
-#[register(base = SBRM_ADDRESS, endianness = LE)]
+#[register_map(base = SBRM_ADDRESS, endianness = LE)]
 pub enum SBRM {
-    #[entry(len = 64, access = RW, ty = String)]
+    #[register(len = 64, access = RW, ty = String)]
     ManufacturerName = "Cameleon\0",
 }
 
 fn main() {
     assert_eq!(ABRM::SIZE, 76);
 
-    let raw_entry = ABRM::GenCpVersionMajor::raw_entry();
-    assert_eq!(raw_entry.offset, 2);
-    assert_eq!(raw_entry.len, 2);
+    let raw_reg = ABRM::GenCpVersionMajor::raw();
+    assert_eq!(raw_reg.offset, 2);
+    assert_eq!(raw_reg.len, 2);
 
     let protection = ABRM::memory_protection();
     assert_eq!(protection.access_right_with_range(0..2), AccessRight::RO);
@@ -37,7 +37,7 @@ fn main() {
         AccessRight::RW
     );
 
-    let raw_entry = SBRM::ManufacturerName::raw_entry();
-    assert_eq!(raw_entry.offset, SBRM_ADDRESS as usize);
-    assert_eq!(raw_entry.len, 64);
+    let raw_reg = SBRM::ManufacturerName::raw();
+    assert_eq!(raw_reg.offset, SBRM_ADDRESS as usize);
+    assert_eq!(raw_reg.len, 64);
 }

--- a/cameleon-impl/tests/macros/visibility.rs
+++ b/cameleon-impl/tests/macros/visibility.rs
@@ -12,35 +12,35 @@ pub struct Memory {
 }
 
 mod register {
-    use cameleon_impl::memory::register;
+    use cameleon_impl::memory::register_map;
 
-    #[register(base = 0, endianness = LE)]
+    #[register_map(base = 0, endianness = LE)]
     pub(super) enum ABRM {
-        #[entry(len = 2, access = RO, ty = u16)]
+        #[register(len = 2, access = RO, ty = u16)]
         GenCpVersionMinor = 321,
 
-        #[entry(len = 2, access = RO, ty = u16)]
+        #[register(len = 2, access = RO, ty = u16)]
         GenCpVersionMajor,
 
-        #[entry(len = 64, access = RW, ty = String)]
+        #[register(len = 64, access = RW, ty = String)]
         ManufacturerName = "Cameleon\0",
 
-        #[entry(len = 8, access = RO, ty = u64)]
+        #[register(len = 8, access = RO, ty = u64)]
         SBRMAddress = super::SBRM_ADDRESS,
     }
 
-    #[register(base = super::SBRM_ADDRESS, endianness = BE)]
+    #[register_map(base = super::SBRM_ADDRESS, endianness = BE)]
     pub(super) enum SBRM {
-        #[entry(len = 8, access = RO, ty = u64)]
+        #[register(len = 8, access = RO, ty = u64)]
         SIRMAddress = super::SIRM_ADDRESS,
 
-        #[entry(len = 4, access = RO, ty = u32)]
+        #[register(len = 4, access = RO, ty = u32)]
         SIRMLength = 0x20,
 
-        #[entry(len = 8, access = RO, ty = u64)]
+        #[register(len = 8, access = RO, ty = u64)]
         EIRMAddress = super::EIRM_ADDRESS,
 
-        #[entry(len = 4, access = RO, ty = u32)]
+        #[register(len = 4, access = RO, ty = u32)]
         EIRMLength = 0x20,
     }
 }

--- a/cameleon-impl/tests/macros/wrong_access_right.rs
+++ b/cameleon-impl/tests/macros/wrong_access_right.rs
@@ -1,11 +1,11 @@
-use cameleon_impl::memory::register;
+use cameleon_impl::memory::register_map;
 
-#[register(base = 0, endianness = LE)]
+#[register_map(base = 0, endianness = LE)]
 pub enum ABRM {
-    #[entry(len = 2, access = Ro, ty = u16)]
+    #[register(len = 2, access = Ro, ty = u16)]
     GenCpVersionMinor = 321,
 
-    #[entry(len = 8, access = RO, ty = u64)]
+    #[register(len = 8, access = RO, ty = u64)]
     SBRMAddress = SBRM_ADDRESS,
 }
 

--- a/cameleon-impl/tests/macros/wrong_access_right.stderr
+++ b/cameleon-impl/tests/macros/wrong_access_right.stderr
@@ -1,5 +1,5 @@
 error: expected NA, RO, WO, or RW
- --> $DIR/wrong_access_right.rs:5:31
+ --> $DIR/wrong_access_right.rs:5:34
   |
-5 |     #[entry(len = 2, access = Ro, ty = u16)]
-  |                               ^^
+5 |     #[register(len = 2, access = Ro, ty = u16)]
+  |                                  ^^

--- a/cameleon-impl/tests/macros/wrong_endianness.rs
+++ b/cameleon-impl/tests/macros/wrong_endianness.rs
@@ -1,19 +1,19 @@
-use cameleon_impl::memory::register;
+use cameleon_impl::memory::register_map;
 
 const SBRM_ADDRESS: u64 = 0x1000;
 
-#[register(base = 0, endianness = Le)]
+#[register_map(base = 0, endianness = Le)]
 pub enum ABRM {
-    #[entry(len = 2, access = RO, ty = u16)]
+    #[register(len = 2, access = RO, ty = u16)]
     GenCpVersionMinor = 321,
 
-    #[entry(len = 2, access = RO, ty = u16)]
+    #[register(len = 2, access = RO, ty = u16)]
     GenCpVersionMajor,
 
-    #[entry(len = 64, access = RW, ty = String)]
+    #[register(len = 64, access = RW, ty = String)]
     ManufacturerName = "Cameleon\0",
 
-    #[entry(len = 8, access = RO, ty = u64)]
+    #[register(len = 8, access = RO, ty = u64)]
     SBRMAddress = SBRM_ADDRESS,
 }
 

--- a/cameleon-impl/tests/macros/wrong_endianness.stderr
+++ b/cameleon-impl/tests/macros/wrong_endianness.stderr
@@ -1,5 +1,5 @@
 error: only BE or LE is allowed for endianness specifier
- --> $DIR/wrong_endianness.rs:5:35
+ --> $DIR/wrong_endianness.rs:5:39
   |
-5 | #[register(base = 0, endianness = Le)]
-  |                                   ^^
+5 | #[register_map(base = 0, endianness = Le)]
+  |                                       ^^

--- a/cameleon-impl/tests/macros/wrong_init_array.rs
+++ b/cameleon-impl/tests/macros/wrong_init_array.rs
@@ -1,8 +1,8 @@
-use cameleon_impl::memory::register;
+use cameleon_impl::memory::register_map;
 
-#[register(base = 0, endianness = LE)]
+#[register_map(base = 0, endianness = LE)]
 enum ABRM {
-    #[entry(len = 4, access = RO, ty = Bytes)]
+    #[register(len = 4, access = RO, ty = Bytes)]
     ProtocolEndianness = &[0xFF, 1000, 0xFF, 0xFF],
 }
 

--- a/cameleon-impl/tests/macros/wrong_ty_attr.rs
+++ b/cameleon-impl/tests/macros/wrong_ty_attr.rs
@@ -1,8 +1,8 @@
-use cameleon_impl::memory::register;
+use cameleon_impl::memory::register_map;
 
-#[register(base = 0, endianness = LE)]
+#[register_map(base = 0, endianness = LE)]
 pub enum ABRM {
-    #[entry(len = 2, access = RO, ty = u32)]
+    #[register(len = 2, access = RO, ty = u32)]
     GenCpVersionMinor = 321,
 }
 

--- a/cameleon-impl/tests/macros/wrong_ty_attr.stderr
+++ b/cameleon-impl/tests/macros/wrong_ty_attr.stderr
@@ -1,5 +1,5 @@
 error: specified len doesn't fit with specified ty
- --> $DIR/wrong_ty_attr.rs:5:19
+ --> $DIR/wrong_ty_attr.rs:5:22
   |
-5 |     #[entry(len = 2, access = RO, ty = u32)]
-  |                   ^
+5 |     #[register(len = 2, access = RO, ty = u32)]
+  |                      ^


### PR DESCRIPTION
As @yawara pointed out, I renamed `#[register]` to `#[register_map]` and `#[entry]` to `#[register]`.
