### PR TITLE
Fix `numeric_value` in `EnumEntryNode`

### DIFF
--- a/genapi/src/enumeration.rs
+++ b/genapi/src/enumeration.rs
@@ -158,7 +158,7 @@ pub struct EnumEntryNode {
     pub(crate) elem_base: NodeElementBase,
 
     pub(crate) value: i64,
-    pub(crate) numeric_values: Vec<f64>,
+    pub(crate) numeric_value: Option<f64>,
     pub(crate) symbolic: Option<String>,
     pub(crate) is_self_clearing: bool,
 }
@@ -175,8 +175,9 @@ impl EnumEntryNode {
     }
 
     #[must_use]
-    pub fn numeric_values(&self) -> &[f64] {
-        &self.numeric_values
+    #[allow(clippy::cast_precision_loss)]
+    pub fn numeric_value(&self) -> f64 {
+        self.numeric_value.unwrap_or_else(|| self.value as f64)
     }
 
     #[must_use]

--- a/genapi/src/parser/enumeration.rs
+++ b/genapi/src/parser/enumeration.rs
@@ -65,8 +65,8 @@ impl Parse for EnumEntryNode {
         let elem_base = node.parse(node_builder, value_builder, cache_builder);
 
         let value = node.parse(node_builder, value_builder, cache_builder);
-        let numeric_values =
-            node.parse_while(NUMERIC_VALUE, node_builder, value_builder, cache_builder);
+        let numeric_value =
+            node.parse_if(NUMERIC_VALUE, node_builder, value_builder, cache_builder);
         let symbolic = node.parse_if(SYMBOLIC, node_builder, value_builder, cache_builder);
         let is_self_clearing = node
             .parse_if(IS_SELF_CLEARING, node_builder, value_builder, cache_builder)
@@ -76,7 +76,7 @@ impl Parse for EnumEntryNode {
             attr_base,
             elem_base,
             value,
-            numeric_values,
+            numeric_value,
             symbolic,
             is_self_clearing,
         }
@@ -96,11 +96,11 @@ mod tests {
                 <EnumEntry Name="Entry0">
                     <Value>0</Value>
                     <NumericValue>1.0</NumericValue>
-                    <NumericValue>10.0</NumericValue>
                     <IsSelfClearing>Yes</IsSelfClearing>
                 </EnumEntry>
                 <EnumEntry Name="Entry1">
                     <Value>1</Value>
+                    <NumericValue>10.0</NumericValue>
                 </EnumEntry>
                 <pValue>MyNode</pValue>
             <PollingTime>10</PollingTime>
@@ -120,12 +120,12 @@ mod tests {
 
         let entry0 = &entries[0];
         assert_eq!(entry0.value(), 0);
-        assert!((entry0.numeric_values()[0] - 1.0).abs() < f64::EPSILON);
-        assert!((entry0.numeric_values()[1] - 10.0).abs() < f64::EPSILON);
+        assert!((entry0.numeric_value() - 1.0).abs() < f64::EPSILON);
         assert_eq!(entry0.is_self_clearing(), true);
 
         let entry1 = &entries[1];
         assert_eq!(entry1.value(), 1);
+        assert!((entry1.numeric_value() - 10.0).abs() < f64::EPSILON);
         assert_eq!(entry1.is_self_clearing(), false);
     }
 }

--- a/genapi/src/utils.rs
+++ b/genapi/src/utils.rs
@@ -198,6 +198,7 @@ impl<'a, T: Copy + Into<Expr>> FormulaEnvCollector<'a, T> {
     }
 }
 
+#[derive(Debug)]
 enum VariableKind<'a> {
     Value,
     Min,
@@ -295,6 +296,11 @@ pub(super) fn expr_from_node_id<T: ValueStore, U: CacheStore>(
         Ok(node.value(device, store, cx)?.into())
     } else if let Some(node) = nid.as_iboolean_kind(store) {
         Ok(node.value(device, store, cx)?.into())
+    } else if let Some(node) = nid.as_ienumeration_kind(store) {
+        Ok(node
+            .current_entry(device, store, cx)?
+            .numeric_value()
+            .into())
     } else {
         Err(GenApiError::invalid_node(
             format!("invalid `pVariable: {}`", nid.name(store)).into(),


### PR DESCRIPTION
Each `EnumEntry` has a numeric value.
If `NumericValue` tag is missing, the integer value of entry is used as a numeric value.