### PR TITLE
Eagerly read u3v device register with maximum length when possible

### DIFF
--- a/cameleon/src/u3v/control_handle.rs
+++ b/cameleon/src/u3v/control_handle.rs
@@ -447,6 +447,7 @@ impl DeviceControl for ControlHandle {
         let payload_alignment = unwrap_or_log!(sirm.payload_size_alignment(self));
         macro_rules! align {
             ($expr:expr, $ty: ty) => {
+                // Payload alignment is always power of two.
                 ($expr + (payload_alignment as $ty - 1)) & !(payload_alignment as $ty - 1)
             };
         }
@@ -464,12 +465,12 @@ impl DeviceControl for ControlHandle {
         let maximum_leader_size = if required_leader_size == 0 {
             payload_transfer_size
         } else {
-            required_leader_size
+            align!(required_leader_size, u32)
         };
         let maximum_trailer_size = if required_trailer_size == 0 {
             payload_transfer_size
         } else {
-            required_trailer_size
+            align!(required_trailer_size, u32)
         };
 
         unwrap_or_log!(sirm.set_payload_transfer_size(self, payload_transfer_size));

--- a/device/src/u3v/protocol/cmd.rs
+++ b/device/src/u3v/protocol/cmd.rs
@@ -126,6 +126,13 @@ impl ReadMem {
         })
     }
 
+    /// Returns maximum read length that corresponding ack length fit into `maximum_ack_len`.
+    pub fn maximum_read_length(maximum_ack_len: usize) -> u16 {
+        (maximum_ack_len - CommandPacket::<ReadMem>::ACK_HEADER_LENGTH)
+            .try_into()
+            .unwrap_or(u16::MAX)
+    }
+
     #[must_use]
     pub fn read_length(&self) -> u16 {
         self.read_length


### PR DESCRIPTION
<!--
Thank you for improving `Cameleon`!

Please fill out the checklist before opening the PR.
-->
Fix #94 

- [x] Check `test_all.sh` is passed.
- [x] Add `fix #{ISSUE_NUMBER}` if the corresponding issue exists.
- [x] Fill out `## Changelog` section. If the change is for only internal use, please write `None` to the section.

<!--
We collect a changelog from a PR description, so please write a brief description about the change in the following `Changelog` section.
-->
## Changelog
* [cameleon-device] Add `ReadMem::maximum_read_length`
* [cameleon] Change u3v `read` strategy to eagerly read register with maximum length as long as possible
* [cameleon] Properly align `leader` and `trailer` size