### PR TITLE
Remove unnecessary dependency on `command_value` in `is_writable` of command node

### DIFF
--- a/genapi/src/command.rs
+++ b/genapi/src/command.rs
@@ -97,7 +97,6 @@ impl ICommand for CommandNode {
         cx: &mut ValueCtxt<T, U>,
     ) -> GenApiResult<bool> {
         Ok(self.elem_base.is_writable(device, store, cx)?
-            && self.command_value.is_writable(device, store, cx)?
             && self.value.is_writable(device, store, cx)?)
     }
 }


### PR DESCRIPTION
<!--
Thank you for improving `Cameleon`!

Please fill out the checklist before opening the PR.
-->

- [x] Check `test_all.sh` is passed.
- [x] Add fix #100 if the corresponding issue exists.
- [x] Fill out `## Changelog` section. If the change is for only internal use, please write `None` to the section.

<!--
We collect a changelog from a PR description, so please write a brief description about the change in the following `Changelog` section.
-->
## Changelog
Remove unnecessary dependency on `command_value` in `is_writable` of command node
