### PR TITLE
Store `EnumEntryNode` to `NodeStore` in the same way like other nodes

### DIFF
--- a/cameleon/src/genapi/mod.rs
+++ b/cameleon/src/genapi/mod.rs
@@ -34,11 +34,12 @@
 //!     gain_node.set_value(&mut params_ctxt, 0.1).unwrap();
 //! }
 //! ```
+
 mod node_kind;
 
 pub use node_kind::{
-    BooleanNode, CategoryNode, CommandNode, EnumerationNode, FloatNode, IntegerNode, Node,
-    PortNode, RegisterNode, StringNode,
+    BooleanNode, CategoryNode, CommandNode, EnumEntryNode, EnumerationNode, FloatNode, IntegerNode,
+    Node, PortNode, RegisterNode, StringNode,
 };
 
 use std::{

--- a/cameleon/src/lib.rs
+++ b/cameleon/src/lib.rs
@@ -123,7 +123,7 @@
 #![allow(
     clippy::similar_names,
     clippy::missing_errors_doc,
-    clippy::clippy::module_name_repetitions
+    clippy::module_name_repetitions
 )]
 
 pub mod camera;

--- a/genapi/src/builder.rs
+++ b/genapi/src/builder.rs
@@ -96,6 +96,9 @@ pub trait NodeStoreBuilder {
     fn get_or_intern<T>(&mut self, node_name: T) -> NodeId
     where
         T: AsRef<str>;
+
+    /// Returns fresh id for each call.
+    fn fresh_id(&mut self) -> u32;
 }
 
 pub trait ValueStoreBuilder {

--- a/genapi/src/parser/converter.rs
+++ b/genapi/src/parser/converter.rs
@@ -129,6 +129,6 @@ mod tests {
         assert_eq!(expressions[0].name(), "ConstBy2");
         assert_eq!(node.p_value(), node_builder.get_or_intern("Target"));
         assert_eq!(node.slope(), Slope::Increasing);
-        assert_eq!(node.is_linear(), true);
+        assert!(node.is_linear());
     }
 }

--- a/genapi/src/parser/elem_name.rs
+++ b/genapi/src/parser/elem_name.rs
@@ -46,7 +46,6 @@ pub(super) const POLLING_TIME: &str = "PollingTime";
 pub(super) const ON_VALUE: &str = "OnValue";
 pub(super) const OFF_VALUE: &str = "OffValue";
 pub(super) const NUMERIC_VALUE: &str = "NumericValue";
-pub(super) const SYMBOLIC: &str = "Symbolic";
 pub(super) const IS_SELF_CLEARING: &str = "IsSelfClearing";
 pub(super) const MIN: &str = "Min";
 pub(super) const P_MIN: &str = "pMin";

--- a/genapi/src/parser/enumeration.rs
+++ b/genapi/src/parser/enumeration.rs
@@ -152,12 +152,12 @@ mod tests {
         assert_eq!(entry0.symbolic(), "Entry0");
         assert_eq!(entry0.value(), 0);
         assert!((entry0.numeric_value() - 1.0).abs() < f64::EPSILON);
-        assert_eq!(entry0.is_self_clearing(), true);
+        assert!(entry0.is_self_clearing());
 
         let entry1 = &entries[1].expect_enum_entry(&node_builder).unwrap();
         assert_eq!(entry1.symbolic(), "Entry1");
         assert_eq!(entry1.value(), 1);
         assert!((entry1.numeric_value() - 10.0).abs() < f64::EPSILON);
-        assert_eq!(entry1.is_self_clearing(), false);
+        assert!(!entry1.is_self_clearing());
     }
 }

--- a/genapi/src/parser/node.rs
+++ b/genapi/src/parser/node.rs
@@ -70,14 +70,14 @@ mod tests {
         assert_eq!(node_base.id(), node_builder.get_or_intern("TestNode"));
         assert_eq!(node_base.name_space(), NameSpace::Standard);
         assert_eq!(node_base.merge_priority(), MergePriority::High);
-        assert_eq!(node_base.expose_static().unwrap(), false);
+        assert!(!node_base.expose_static().unwrap());
 
         assert_eq!(node_base.tooltip().unwrap(), "tooltip");
         assert_eq!(node_base.description().unwrap(), "the description");
         assert_eq!(node_base.display_name(), Some("display name"));
         assert_eq!(node_base.visibility(), Visibility::Guru);
         assert_eq!(node_base.docu_url().unwrap(), "http://FOO.com");
-        assert_eq!(node_base.is_deprecated(), true);
+        assert!(node_base.is_deprecated());
         assert_eq!(node_base.event_id(), Some(0xF1));
         assert_eq!(
             node_base.p_is_implemented().unwrap(),
@@ -133,7 +133,7 @@ mod tests {
         assert_eq!(node_base.display_name(), None);
         assert_eq!(node_base.visibility(), Visibility::Beginner);
         assert!(node_base.docu_url().is_none());
-        assert_eq!(node_base.is_deprecated(), false);
+        assert!(!node_base.is_deprecated());
         assert!(node_base.event_id().is_none());
         assert!(node_base.p_is_implemented().is_none());
         assert!(node_base.p_is_available().is_none());

--- a/genapi/src/parser/port.rs
+++ b/genapi/src/parser/port.rs
@@ -73,7 +73,7 @@ mod tests {
 
         let (node, ..): (PortNode, _, _, _) = parse_default(xml);
         assert_eq!(node.chunk_id().unwrap(), &ImmOrPNode::Imm(0x00FD_3219));
-        assert_eq!(node.swap_endianness(), true);
+        assert!(node.swap_endianness());
     }
 
     #[test]
@@ -101,6 +101,6 @@ mod tests {
 
         let (node, ..): (PortNode, _, _, _) = parse_default(xml);
         assert_eq!(node.chunk_id(), None);
-        assert_eq!(node.cache_chunk_data(), true);
+        assert!(node.cache_chunk_data());
     }
 }

--- a/genapi/src/parser/string.rs
+++ b/genapi/src/parser/string.rs
@@ -65,7 +65,7 @@ mod tests {
         "#;
 
         let (node, _, value_builder, _): (StringNode, _, _, _) = parse_default(xml);
-        assert_eq!(node.streamable(), true);
+        assert!(node.streamable());
         let value = value_builder
             .str_value(node.value_elem().imm().unwrap())
             .unwrap();
@@ -81,7 +81,7 @@ mod tests {
         "#;
 
         let (node, mut node_builder, ..): (StringNode, _, _, _) = parse_default(xml);
-        assert_eq!(node.streamable(), false);
+        assert!(!node.streamable());
         assert_eq!(
             node.value_elem(),
             ImmOrPNode::PNode(node_builder.get_or_intern("AnotherStringNode"))

--- a/genapi/src/utils.rs
+++ b/genapi/src/utils.rs
@@ -271,8 +271,9 @@ impl<'a> VariableKind<'a> {
             }
             Self::Enum(name) => {
                 if let Some(node) = nid.as_ienumeration_kind(store) {
-                    node.entry_by_name(name, store)
-                        .ok_or_else(|| error(nid, store))?
+                    node.entry_by_symbolic(name, store)
+                        .ok_or_else(|| error(nid, store))
+                        .map(|nid| nid.expect_enum_entry(store).unwrap())?
                         .value()
                         .into()
                 } else {
@@ -363,7 +364,8 @@ fn expr_from_nid<T: ValueStore, U: CacheStore>(
     } else if let Some(node) = nid.as_iboolean_kind(store) {
         node.value(device, store, cx)?.into()
     } else if let Some(node) = nid.as_ienumeration_kind(store) {
-        node.current_entry(device, store, cx)?
+        node.current_entry(device, store, cx)
+            .map(|nid| nid.expect_enum_entry(store).unwrap())?
             .numeric_value()
             .into()
     } else {


### PR DESCRIPTION
fixes  #99 

- [x] Check `test_all.sh` is passed.
- [x] Add `fix #{ISSUE_NUMBER}` if the corresponding issue exists.
- [x] Fill out `## Changelog` section. If the change is for only internal use, please write `None` to the section.

## Changelog
* [cameleon-genapi] Make `EnumEntryNode` have `NodeId` as other nodes
    * Change `EnumerationNode::entries` to return `&[NodeId]`
    * `EnumerationNode::set_entry_by_name` -> `EnumerationNode::set_entry_by_symbolic`
    * `EnumerationNode::entry_by_name` -> `EnumerationNode::entry_by_symbolic`
    * Add `Node::as_enum_entry_node`
    * Remove `IEnumerationKind::entries_precise`

* [cameleon] Add `EnumEntryNode`
   * Change `EnumerationNode::entries` to return `Vec<EnumerationNode>`
   * Change `EnumEntryNode::current_entry` to return `EnumerationNode`