### PR TITLE
Add support for `WinUSB`

### DIFF
--- a/cameleon/Cargo.toml
+++ b/cameleon/Cargo.toml
@@ -26,16 +26,13 @@ tracing = "0.1.26"
 auto_impl = "0.4.1"
 cameleon-device = { path = "../device", version = "0.1.1" }
 cameleon-genapi = { path = "../genapi", version = "0.1.1" }
-rusb = { version = "0.8.1", optional = true }
-libusb1-sys = { version = "0.5.0", optional = true }
-libc = { version = "0.2", optional = true }
 anyhow = "1.0.40"
 
 [dev-dependencies]
 trybuild = "1.0.42"
 
 [features]
-libusb = ["cameleon-device/libusb", "rusb", "libc", "libusb1-sys"]
+libusb = ["cameleon-device/libusb"]
 
 [[example]]
 name = "u3v_register_map"

--- a/cameleon/src/u3v/mod.rs
+++ b/cameleon/src/u3v/mod.rs
@@ -49,8 +49,6 @@ pub mod control_handle;
 pub mod register_map;
 pub mod stream_handle;
 
-mod async_read;
-
 pub use control_handle::{ControlHandle, SharedControlHandle};
 pub use stream_handle::{StreamHandle, StreamParams};
 

--- a/cameleon/src/u3v/stream_handle.rs
+++ b/cameleon/src/u3v/stream_handle.rs
@@ -11,7 +11,7 @@ use std::{
 };
 
 use async_std::task;
-use cameleon_device::u3v::{self, protocol::stream as u3v_stream};
+use cameleon_device::u3v::{self, async_read::AsyncPool, protocol::stream as u3v_stream};
 use futures::channel::oneshot;
 use tracing::{error, info, warn};
 
@@ -21,7 +21,7 @@ use crate::{
     ControlError, ControlResult, DeviceControl, StreamError, StreamResult,
 };
 
-use super::{async_read::AsyncPool, register_map::Abrm};
+use super::register_map::Abrm;
 
 /// This type is used to receive stream packets from the device.
 pub struct StreamHandle {

--- a/device/Cargo.toml
+++ b/device/Cargo.toml
@@ -26,12 +26,15 @@ rand = "0.8.3"
 cameleon-impl = { path = "../impl", version = "0.1.0" }
 
 rusb = { version = "0.8.1", optional = true }
+libusb1-sys = { version = "0.5.0", optional = true }
+libc = { version = "0.2", optional = true }
+
 
 [dev-dependencies]
 trybuild = "1.0.42"
 
 [features]
-libusb = ["rusb"]
+libusb = ["rusb", "libusb1-sys", "libc"]
 
 [[example]]
 name = "u3v_device_enumeration"

--- a/device/Cargo.toml
+++ b/device/Cargo.toml
@@ -23,6 +23,7 @@ const_format = "0.2.14"
 futures = "0.3.14"
 lazy_static = "1.4.0"
 rand = "0.8.3"
+cfg-if = "1.0.0"
 cameleon-impl = { path = "../impl", version = "0.1.0" }
 
 rusb = { version = "0.8.1", optional = true }

--- a/device/src/u3v/async_read.rs
+++ b/device/src/u3v/async_read.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#![doc(hidden)]
 //! This module contains libusb async api wrapper without any overhead.
 //! NEVER make this module public because all functions in this module may cause UB if
 //! preconditions are not followed.
@@ -16,27 +17,27 @@ use std::{
     time::{Duration, Instant},
 };
 
-use cameleon_device::u3v::ReceiveChannel;
+use super::{LibUsbError, ReceiveChannel, Result};
 use rusb::UsbContext;
-use thiserror::Error;
 
-use crate::{StreamError, StreamResult};
-
+#[doc(hidden)]
 /// Represents a pool of asynchronous transfers, that can be polled to completion.
-pub(super) struct AsyncPool<'a> {
+pub struct AsyncPool<'a> {
     device: &'a ReceiveChannel,
     pending: VecDeque<AsyncTransfer>,
 }
 
 impl<'a> AsyncPool<'a> {
-    pub(super) fn new(device: &'a ReceiveChannel) -> Self {
+    #[doc(hidden)]
+    pub fn new(device: &'a ReceiveChannel) -> Self {
         Self {
             device,
             pending: VecDeque::new(),
         }
     }
 
-    pub(super) fn submit(&mut self, buf: &mut [u8]) -> StreamResult<()> {
+    #[doc(hidden)]
+    pub fn submit(&mut self, buf: &mut [u8]) -> Result<()> {
         // Safety: If transfer is submitted, it is pushed onto `pending` where it will be
         // dropped before `device` is freed.
         unsafe {
@@ -51,8 +52,13 @@ impl<'a> AsyncPool<'a> {
         }
     }
 
-    pub(super) fn poll(&mut self, timeout: Duration) -> StreamResult<usize> {
-        let next = self.pending.front().ok_or(AsyncError::NoTransfersPending)?;
+    #[doc(hidden)]
+    /// # Panics
+    ///
+    /// Panics if there is no pending transfer.
+    pub fn poll(&mut self, timeout: Duration) -> Result<usize> {
+        debug_assert!(!self.pending.is_empty());
+        let next = self.pending.front().unwrap();
         if poll_completed(
             self.device.device_handle.context(),
             timeout,
@@ -61,11 +67,12 @@ impl<'a> AsyncPool<'a> {
             let mut transfer = self.pending.pop_front().unwrap();
             Ok(transfer.handle_completed()?)
         } else {
-            Err(AsyncError::Timeout.into())
+            Err(LibUsbError::Timeout.into())
         }
     }
 
-    pub(super) fn cancel_all(&mut self) {
+    #[doc(hidden)]
+    pub fn cancel_all(&mut self) {
         // Cancel in reverse order to avoid a race condition in which one
         // transfer is cancelled but another submitted later makes its way onto
         // the bus.
@@ -75,12 +82,14 @@ impl<'a> AsyncPool<'a> {
     }
 
     /// Returns the number of async transfers pending.
-    pub(super) fn pending(&self) -> usize {
+    #[doc(hidden)]
+    pub fn pending(&self) -> usize {
         self.pending.len()
     }
 
     /// Returns `true` if there is no pending transfer.
-    pub(super) fn is_empty(&self) -> bool {
+    #[doc(hidden)]
+    pub fn is_empty(&self) -> bool {
         self.pending() == 0
     }
 }
@@ -154,10 +163,10 @@ impl AsyncTransfer {
     }
 
     // Step 3 of async API
-    fn submit(&mut self) -> StreamResult<()> {
+    fn submit(&mut self) -> Result<()> {
         self.completed_flag().store(false, SeqCst);
         let errno = unsafe { libusb1_sys::libusb_submit_transfer(self.ptr.as_ptr()) };
-        Ok(AsyncError::from_libusb_error(errno)?)
+        Ok(LibUsbError::from_libusb_error(errno)?)
     }
 
     fn cancel(&mut self) {
@@ -166,7 +175,7 @@ impl AsyncTransfer {
         }
     }
 
-    fn handle_completed(&mut self) -> StreamResult<usize> {
+    fn handle_completed(&mut self) -> Result<usize> {
         assert!(self
             .completed_flag()
             .load(std::sync::atomic::Ordering::Relaxed));
@@ -177,14 +186,14 @@ impl AsyncTransfer {
                 debug_assert!(transfer.length >= transfer.actual_length);
                 return Ok(transfer.actual_length as usize);
             }
-            LIBUSB_TRANSFER_CANCELLED => AsyncError::Cancelled,
-            LIBUSB_TRANSFER_ERROR => AsyncError::Other,
+            LIBUSB_TRANSFER_CANCELLED => LibUsbError::Timeout,
+            LIBUSB_TRANSFER_ERROR => LibUsbError::Other,
             LIBUSB_TRANSFER_TIMED_OUT => {
                 unreachable!("We are using timeout=0 which means no timeout")
             }
-            LIBUSB_TRANSFER_STALL => AsyncError::Stall,
-            LIBUSB_TRANSFER_NO_DEVICE => AsyncError::Disconnected,
-            LIBUSB_TRANSFER_OVERFLOW => AsyncError::Overflow,
+            LIBUSB_TRANSFER_STALL => LibUsbError::Pipe,
+            LIBUSB_TRANSFER_NO_DEVICE => LibUsbError::NoDevice,
+            LIBUSB_TRANSFER_OVERFLOW => LibUsbError::Overflow,
             _ => unreachable!(),
         };
         Err(err.into())
@@ -211,7 +220,7 @@ fn poll_completed(
     ctx: &impl UsbContext,
     timeout: Duration,
     completed: &AtomicBool,
-) -> StreamResult<bool> {
+) -> Result<bool> {
     use libusb1_sys::{constants::*, *};
 
     let deadline = Instant::now() + timeout;
@@ -242,51 +251,13 @@ fn poll_completed(
         match err {
             0 => Ok(completed.load(SeqCst)),
             LIBUSB_ERROR_TIMEOUT => Ok(false),
-            e => Err(AsyncError::from_libusb_error(e).unwrap_err().into()),
+            e => Err(LibUsbError::from_libusb_error(e).unwrap_err().into()),
         }
     }
 }
 
-#[derive(Error, Debug)]
-enum AsyncError {
-    #[error("no transfers pending")]
-    NoTransfersPending,
-    #[error("transfer is stalled")]
-    Stall,
-    #[error("device was disconnected")]
-    Disconnected,
-    #[error("transfer was cancelled")]
-    Cancelled,
-    #[error("input/output error")]
-    Io,
-    #[error("invalid parameter")]
-    InvalidParam,
-    #[error("access denied (insufficient permissions)")]
-    Access,
-    #[error("no such device (it may have been disconnected)")]
-    NoDevice,
-    #[error("entity not found")]
-    NotFound,
-    #[error("resource busy")]
-    Busy,
-    #[error("operation timed out")]
-    Timeout,
-    #[error("overflow")]
-    Overflow,
-    #[error("pipe error")]
-    Pipe,
-    #[error("system call interrupted (perhaps due to signal)")]
-    Interrupted,
-    #[error("insufficient memory")]
-    NoMem,
-    #[error("operation not supported or unimplemented on this platform")]
-    NotSupported,
-    #[error("other error")]
-    Other,
-}
-
-impl AsyncError {
-    fn from_libusb_error(err: i32) -> Result<(), Self> {
+impl LibUsbError {
+    fn from_libusb_error(err: i32) -> std::result::Result<(), Self> {
         match err {
             0 => Ok(()),
             libusb1_sys::constants::LIBUSB_ERROR_IO => Err(Self::Io),
@@ -303,15 +274,6 @@ impl AsyncError {
             libusb1_sys::constants::LIBUSB_ERROR_NOT_SUPPORTED => Err(Self::NotSupported),
             libusb1_sys::constants::LIBUSB_ERROR_OTHER => Err(Self::Other),
             _ => unreachable!(),
-        }
-    }
-}
-
-impl From<AsyncError> for StreamError {
-    fn from(err: AsyncError) -> Self {
-        match err {
-            AsyncError::Disconnected => Self::Disconnected,
-            _ => StreamError::Io(err.into()),
         }
     }
 }

--- a/device/src/u3v/channel.rs
+++ b/device/src/u3v/channel.rs
@@ -6,10 +6,10 @@ use std::time;
 
 use crate::u3v::Result;
 
-use super::device::RusbDevHandle;
+use super::device::LibUsbDeviceHandle;
 
 pub struct ControlChannel {
-    pub device_handle: RusbDevHandle,
+    pub(super) device_handle: LibUsbDeviceHandle,
     pub iface_info: ControlIfaceInfo,
     pub is_opened: bool,
 }
@@ -65,7 +65,7 @@ impl ControlChannel {
         Ok(())
     }
 
-    pub(super) fn new(device_handle: RusbDevHandle, iface_info: ControlIfaceInfo) -> Self {
+    pub(super) fn new(device_handle: LibUsbDeviceHandle, iface_info: ControlIfaceInfo) -> Self {
         Self {
             device_handle,
             iface_info,
@@ -75,7 +75,7 @@ impl ControlChannel {
 }
 
 pub struct ReceiveChannel {
-    pub device_handle: RusbDevHandle,
+    pub(super) device_handle: LibUsbDeviceHandle,
     pub iface_info: ReceiveIfaceInfo,
     pub is_opened: bool,
 }
@@ -123,7 +123,7 @@ impl ReceiveChannel {
         Ok(())
     }
 
-    pub(super) fn new(device_handle: RusbDevHandle, iface_info: ReceiveIfaceInfo) -> Self {
+    pub(super) fn new(device_handle: LibUsbDeviceHandle, iface_info: ReceiveIfaceInfo) -> Self {
         Self {
             device_handle,
             iface_info,
@@ -145,7 +145,11 @@ pub struct ReceiveIfaceInfo {
     pub bulk_in_ep: u8,
 }
 
-fn set_halt(handle: &RusbDevHandle, endpoint_number: u8, timeout: time::Duration) -> Result<()> {
+fn set_halt(
+    handle: &LibUsbDeviceHandle,
+    endpoint_number: u8,
+    timeout: time::Duration,
+) -> Result<()> {
     let request_type = rusb::request_type(
         rusb::Direction::Out,
         rusb::RequestType::Standard,

--- a/device/src/u3v/device.rs
+++ b/device/src/u3v/device.rs
@@ -6,16 +6,12 @@ use crate::u3v::{DeviceInfo, Result};
 
 use super::channel::{ControlChannel, ControlIfaceInfo, ReceiveChannel, ReceiveIfaceInfo};
 
-pub(super) type RusbDevHandle = rusb::DeviceHandle<rusb::GlobalContext>;
-pub(super) type RusbDevice = rusb::Device<rusb::GlobalContext>;
-
 /// Entry point to the connected device.
 /// This device itself doesn't communicate with the connected device but provide basic device
 /// information and channels to communicate with the connected device. So it's valid to use
 /// provided channels even after dropping this instance.
-#[derive(Debug)]
 pub struct Device {
-    device: RusbDevice,
+    device: LibUsbDevice,
 
     ctrl_iface_info: ControlIfaceInfo,
     event_iface_info: Option<ReceiveIfaceInfo>,
@@ -66,6 +62,8 @@ impl Device {
         stream_iface_info: Option<ReceiveIfaceInfo>,
         device_info: DeviceInfo,
     ) -> Self {
+        let device = get_device(device);
+
         let device = Self {
             device,
             ctrl_iface_info,
@@ -75,7 +73,6 @@ impl Device {
         };
 
         log::info! {"{}: create device", device.log_name()};
-
         device
     }
 
@@ -87,5 +84,123 @@ impl Device {
             self.device_info.model_name,
             self.device_info.serial_number,
         )
+    }
+}
+
+pub(super) type RusbDevice = rusb::Device<rusb::GlobalContext>;
+pub(super) type RusbDeviceHandle = rusb::DeviceHandle<rusb::GlobalContext>;
+
+cfg_if::cfg_if! {
+    if #[cfg(target_os = "windows")] {
+        use std::{
+            sync::{Arc, Mutex},
+            time,
+        };
+
+        pub(super) struct LibUsbDevice {
+            pub(super) handle: LibUsbDeviceHandle,
+        }
+        impl LibUsbDevice {
+            pub(super) fn open(&self) -> Result<LibUsbDeviceHandle> {
+                Ok(self.handle.clone())
+            }
+
+            fn new(device: RusbDevice) -> Self {
+                let handle = LibUsbDeviceHandle {
+                    device: Arc::new(Mutex::new(device)),
+                    handle: Arc::new(Mutex::new(None)),
+                };
+
+                Self { handle }
+            }
+        }
+
+        #[derive(Clone)]
+        pub(super) struct LibUsbDeviceHandle {
+            device: Arc<Mutex<RusbDevice>>,
+            pub(super) handle: Arc<Mutex<Option<RusbDeviceHandle>>>,
+        }
+        macro_rules! delegate {
+            ($handle:expr, $method:ident($($args:ident),*)) => {
+                if let Some(handle) = &mut *$handle {
+                    handle.$method($($args),*).map_err(Into::into)
+                } else {
+                    Err(super::LibUsbError::Io.into())
+                }
+            }
+        }
+        impl LibUsbDeviceHandle {
+            pub(super) fn claim_interface(&mut self, iface: u8) -> Result<()> {
+                let mut handle = self.handle.lock().unwrap();
+                if handle.is_none() {
+                    let device = self.device.lock().unwrap();
+                    *handle = device.open()?.into();
+                }
+
+                delegate!(handle, claim_interface(iface))
+            }
+
+            pub(super) fn release_interface(&mut self, iface: u8) -> Result<()> {
+                let mut handle = self.handle.lock().unwrap();
+                if let Some(handle) = &mut *handle {
+                    handle.release_interface(iface).map_err(Into::into)
+                } else {
+                    Ok(())
+                }
+            }
+
+            pub(super) fn read_bulk(
+                &self,
+                endpoint: u8,
+                buf: &mut [u8],
+                timeout: time::Duration,
+            ) -> Result<usize> {
+                let mut handle = self.handle.lock().unwrap();
+                delegate!(handle, read_bulk(endpoint, buf, timeout))
+            }
+
+            pub(super) fn write_bulk(
+                &self,
+                endpoint: u8,
+                buf: &[u8],
+                timeout: time::Duration,
+            ) -> Result<usize> {
+                let mut handle = self.handle.lock().unwrap();
+                delegate!(handle, write_bulk(endpoint, buf, timeout))
+            }
+
+            pub(super) fn clear_halt(&mut self, endpoint: u8) -> Result<()> {
+                let mut handle = self.handle.lock().unwrap();
+                delegate!(handle, clear_halt(endpoint))
+            }
+
+            pub(super) fn write_control(
+                &self,
+                request_type: u8,
+                request: u8,
+                value: u16,
+                index: u16,
+                buf: &[u8],
+                timeout: time::Duration,
+            ) -> Result<usize> {
+                let mut handle = self.handle.lock().unwrap();
+                delegate!(
+                    handle,
+                    write_control(request_type, request, value, index, buf, timeout)
+                )
+            }
+        }
+
+        fn get_device(device:RusbDevice) -> LibUsbDevice {
+            LibUsbDevice::new(device)
+        }
+    } else {
+        pub(super) type LibUsbDevice = RusbDevice;
+        pub(super) type LibUsbDeviceHandle = RusbDeviceHandle;
+
+        fn get_device(device: RusbDevice) -> LibUsbDevice {
+            device
+        }
+
     }
 }

--- a/device/src/u3v/device_builder.rs
+++ b/device/src/u3v/device_builder.rs
@@ -8,7 +8,7 @@ use crate::u3v::{protocol::util::ReadBytes, BusSpeed, DeviceInfo, Error, Result}
 
 use super::{
     channel::{ControlIfaceInfo, ReceiveIfaceInfo},
-    device::{Device, RusbDevHandle, RusbDevice},
+    device::{Device, RusbDevice, RusbDeviceHandle},
 };
 
 const MISCELLANEOUS_CLASS: u8 = 0xEF;
@@ -326,7 +326,7 @@ impl DeviceInfoDescriptor {
         })
     }
 
-    fn interpret(&self, channel: &RusbDevHandle) -> Result<DeviceInfo> {
+    fn interpret(&self, channel: &RusbDeviceHandle) -> Result<DeviceInfo> {
         let gencp_version = Version::new(
             self.gencp_version_major.into(),
             self.gencp_version_minor.into(),

--- a/device/src/u3v/mod.rs
+++ b/device/src/u3v/mod.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+pub mod async_read;
 pub mod protocol;
 pub mod register_map;
 pub mod prelude {


### PR DESCRIPTION
Add support for `WinUSB`.
ref #104 

- [x] Check `test_all.sh` is passed.
- [ ] Add `fix #{ISSUE_NUMBER}` if the corresponding issue exists.
- [x] Fill out `## Changelog` section. If the change is for only internal use, please write `None` to the section.

<!--
We collect a changelog from a PR description, so please write a brief description about the change in the following `Changelog` section.
-->
## Changelog
* [cameleon-device] Fix bugs related to `WinUSB`
* [cameleon-device] Make fields of `ControlChannel`  and `ReceiveChanel` private
