### PR TITLE
Make `CameleonError` (thus all other errors) `Send` + `Sync`

### DIFF
--- a/cameleon/src/camera.rs
+++ b/cameleon/src/camera.rs
@@ -513,7 +513,7 @@ impl<Ctrl, Strm, Ctxt> Camera<Ctrl, Strm, Ctxt> {
 }
 
 /// Information of the camera.
-#[derive(Clone, Debug, PartialEq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct CameraInfo {
     /// Vendor name of the camera.
     pub vendor_name: String,

--- a/cameleon/src/genapi/mod.rs
+++ b/cameleon/src/genapi/mod.rs
@@ -435,7 +435,7 @@ where
         &mut self,
         address: i64,
         data: &mut [u8],
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let address: u64 = address.try_into().map_err(|_| {
             ControlError::InvalidData(
                 "invalid address: the given address has negative value".into(),
@@ -448,7 +448,7 @@ where
         &mut self,
         address: i64,
         data: &[u8],
-    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
+    ) -> std::result::Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let address: u64 = address.try_into().map_err(|_| {
             ControlError::InvalidData(
                 "invalid address: the given address has negative value".into(),

--- a/cameleon/src/lib.rs
+++ b/cameleon/src/lib.rs
@@ -217,7 +217,7 @@ pub enum ControlError {
     /// Try to write invalid data to the device, or received data from the device is semantically invalid.
     /// e.g. try to write too large data that will overrun register.
     #[error("try to write invalid data to the device: {0}")]
-    InvalidData(Box<dyn std::error::Error>),
+    InvalidData(Box<dyn std::error::Error + Send + Sync>),
 }
 
 /// A specialized `Result` type for streaming.
@@ -269,4 +269,21 @@ impl From<TryFromIntError> for ControlError {
     fn from(e: TryFromIntError) -> Self {
         Self::InvalidDevice(format!("internal data has invalid num type: {}", e).into())
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Taken from https://stackoverflow.com/a/32765782/4345715
+    // Can be replaced by https://crates.io/crates/static_assertions
+    const _: () = {
+        fn assert_send<T: Send>() {}
+        fn assert_sync<T: Sync>() {}
+
+        fn assert_cameleon_error_is_send_sync() {
+            assert_send::<CameleonError>();
+            assert_sync::<CameleonError>();
+        }
+    };
 }

--- a/device/src/u3v/protocol/cmd.rs
+++ b/device/src/u3v/protocol/cmd.rs
@@ -450,7 +450,7 @@ impl<'a> CommandScd for WriteMem<'a> {
     }
 }
 
-impl<'a> CommandScd for ReadMemStacked {
+impl CommandScd for ReadMemStacked {
     fn flag(&self) -> CommandFlag {
         CommandFlag::RequestAck
     }

--- a/genapi/src/elem_type.rs
+++ b/genapi/src/elem_type.rs
@@ -40,7 +40,7 @@ pub enum AccessMode {
     RW,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ImmOrPNode<T> {
     Imm(T),
     PNode(NodeId),
@@ -139,7 +139,7 @@ pub enum CachingMode {
     NoCache,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NamedValue<T> {
     pub(crate) name: String,
     pub(crate) value: T,

--- a/genapi/src/lib.rs
+++ b/genapi/src/lib.rs
@@ -80,15 +80,23 @@ pub mod prelude {
 
 #[auto_impl(&mut, Box)]
 pub trait Device {
-    fn read_mem(&mut self, address: i64, buf: &mut [u8]) -> Result<(), Box<dyn std::error::Error>>;
+    fn read_mem(
+        &mut self,
+        address: i64,
+        buf: &mut [u8],
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>>;
 
-    fn write_mem(&mut self, address: i64, data: &[u8]) -> Result<(), Box<dyn std::error::Error>>;
+    fn write_mem(
+        &mut self,
+        address: i64,
+        data: &[u8],
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>>;
 }
 
 #[derive(Debug, thiserror::Error)]
 pub enum GenApiError {
     #[error("device I/O error: {0}")]
-    Device(Box<dyn std::error::Error>),
+    Device(Box<dyn std::error::Error + Send + Sync>),
 
     /// The node is not writable.
     #[error("attempt to write a value to non writable node")]
@@ -114,7 +122,7 @@ pub enum GenApiError {
 }
 
 impl GenApiError {
-    fn device(inner: Box<dyn std::error::Error>) -> Self {
+    fn device(inner: Box<dyn std::error::Error + Send + Sync>) -> Self {
         let err = GenApiError::Device(inner);
         error!("{}", err);
         err


### PR DESCRIPTION
Libraries like `anyhow` require wrapped errors to be Send and Sync, so this is hopefully a reasonable requirement.

We've faced this limitation when we wanted to wrap `CameleonError` in our application.

Note that this changes the public API of `cameleon_genapi::Device`.

CC @bschwind.

<!--
Thank you for improving `Cameleon`!

Please fill out the checklist before opening the PR.
-->

- [x] Check `test_all.sh` is passed.
- [x] Add `fix #{ISSUE_NUMBER}` if the corresponding issue exists.
- [x] Fill out `## Changelog` section. If the change is for only internal use, please write `None` to the section.

<!--
We collect a changelog from a PR description, so please write a brief description about the change in the following `Changelog` section.
-->
## Changelog
- `camelon::CameleonError` and all other public errors in the `cameleon` suite are now `Send` + `Sync`.
- `cameleon_genapi::Device` trait API has changed. Errors returned from its methods now must also implement `Send` + `Sync`.