### PR TITLE
Fix genicam parser

### DIFF
--- a/device/src/u3v/protocol/ack.rs
+++ b/device/src/u3v/protocol/ack.rs
@@ -484,7 +484,7 @@ mod tests {
     #[test]
     fn test_write_mem_stacked_ack() {
         let mut scd = vec![0x00, 0x00, 0x03, 0x00]; // Written length 0: 3 bytes written.
-        scd.extend(&[0x00, 0x00, 0x0a, 0x00]); // Written length 1: 10 bytes written.
+        scd.extend([0x00, 0x00, 0x0a, 0x00]); // Written length 1: 10 bytes written.
         let mut raw_packet = serialize_header(0x0000, 0x0809, scd.len() as u16, 1);
         raw_packet.extend(&scd);
 

--- a/device/src/u3v/protocol/cmd.rs
+++ b/device/src/u3v/protocol/cmd.rs
@@ -518,10 +518,10 @@ mod tests {
     fn serialize_header(command_id: [u8; 2], scd_len: [u8; 2], req_id: [u8; 2]) -> Vec<u8> {
         let mut ccd = vec![];
         ccd.write_bytes_le(0x4356_3355_u32).unwrap(); // Magic.
-        ccd.extend(&[0x00, 0x40]); // Packet flag: Request Ack.
-        ccd.extend(&command_id);
-        ccd.extend(&scd_len);
-        ccd.extend(&req_id);
+        ccd.extend([0x00, 0x40]); // Packet flag: Request Ack.
+        ccd.extend(command_id);
+        ccd.extend(scd_len);
+        ccd.extend(req_id);
         ccd
     }
 

--- a/genapi/src/node_base.rs
+++ b/genapi/src/node_base.rs
@@ -129,6 +129,9 @@ pub(crate) struct NodeElementBase {
     pub(crate) p_errors: Vec<NodeId>,
     pub(crate) p_alias: Option<NodeId>,
     pub(crate) p_cast_alias: Option<NodeId>,
+    /// `pInvalidator` works only for `Register` kind nodes. It is not used in this crate.
+    /// See https://github.com/cameleon-rs/cameleon/issues/138 for more details.
+    pub(crate) p_invalidators: Vec<NodeId>,
 }
 
 impl NodeElementBase {

--- a/genapi/src/parser/node_base.rs
+++ b/genapi/src/parser/node_base.rs
@@ -12,8 +12,8 @@ use super::{
     elem_name::{
         DESCRIPTION, DISPLAY_NAME, DOCU_URL, EVENT_ID, EXPOSE_STATIC, EXTENSION,
         IMPOSED_ACCESS_MODE, IS_DEPRECATED, MERGE_PRIORITY, NAME, NAME_SPACE, P_ALIAS,
-        P_BLOCK_POLLING, P_CAST_ALIAS, P_ERROR, P_IS_AVAILABLE, P_IS_IMPLEMENTED, P_IS_LOCKED,
-        TOOL_TIP, VISIBILITY,
+        P_BLOCK_POLLING, P_CAST_ALIAS, P_ERROR, P_INVALIDATOR, P_IS_AVAILABLE, P_IS_IMPLEMENTED,
+        P_IS_LOCKED, TOOL_TIP, VISIBILITY,
     },
     elem_type::convert_to_bool,
     xml, Parse,
@@ -27,7 +27,7 @@ impl Parse for NodeAttributeBase {
         _: &mut impl CacheStoreBuilder,
     ) -> Self {
         let name = node.attribute_of(NAME).unwrap();
-        let id = node_builder.get_or_intern(&name);
+        let id = node_builder.get_or_intern(name);
         let name_space = node
             .attribute_of(NAME_SPACE)
             .map(|text| text.into())
@@ -89,6 +89,8 @@ impl Parse for NodeElementBase {
         let p_errors = node.parse_while(P_ERROR, node_builder, value_builder, cache_builder);
         let p_alias = node.parse_if(P_ALIAS, node_builder, value_builder, cache_builder);
         let p_cast_alias = node.parse_if(P_CAST_ALIAS, node_builder, value_builder, cache_builder);
+        let p_invalidators =
+            node.parse_while(P_INVALIDATOR, node_builder, value_builder, cache_builder);
 
         Self {
             tooltip,
@@ -106,6 +108,7 @@ impl Parse for NodeElementBase {
             p_errors,
             p_alias,
             p_cast_alias,
+            p_invalidators,
         }
     }
 }

--- a/genapi/src/parser/register_base.rs
+++ b/genapi/src/parser/register_base.rs
@@ -5,6 +5,7 @@
 use crate::{
     builder::{CacheStoreBuilder, NodeStoreBuilder, ValueStoreBuilder},
     elem_type::AccessMode,
+    node_base::NodeElementBase,
     store::NodeId,
     RegisterBase,
 };
@@ -36,7 +37,7 @@ impl Parse for RegisterBase {
         value_builder: &mut impl ValueStoreBuilder,
         cache_builder: &mut impl CacheStoreBuilder,
     ) -> Self {
-        let elem_base = node.parse(node_builder, value_builder, cache_builder);
+        let elem_base: NodeElementBase = node.parse(node_builder, value_builder, cache_builder);
 
         let streamable = node
             .parse_if(STREAMABLE, node_builder, value_builder, cache_builder)
@@ -61,6 +62,9 @@ impl Parse for RegisterBase {
         let polling_time = node.parse_if(POLLING_TIME, node_builder, value_builder, cache_builder);
         let p_invalidators =
             node.parse_while(P_INVALIDATOR, node_builder, value_builder, cache_builder);
+
+        // Ensure `ElementBase` doesn't consume `p]invalidator`.
+        debug_assert!(elem_base.p_invalidators.is_empty());
 
         Self {
             elem_base,

--- a/impl/macros/src/register_map.rs
+++ b/impl/macros/src/register_map.rs
@@ -436,7 +436,7 @@ impl Register {
     fn impl_write(&self, endianness: Endianness) -> TokenStream {
         match &self.reg_attr.ty {
             RegisterType::BitField(ref bf) => {
-                let read_bytes = quote_read_bytes(endianness, &*bf.ty);
+                let read_bytes = quote_read_bytes(endianness, &bf.ty);
                 let write_bytes = quote_write_bytes(endianness);
                 quote! {
                     fn write(data: Self::Ty, memory: &mut[u8]) -> MemoryResult<()> {


### PR DESCRIPTION
Fix #138 

When the GenICam XML follows schema version 1.1, non-register type nodes can have a `pInvalidator` element, though `cameleon` doesn't use the feature if it's a non-register type.
So this fix simply changes to include `pInvalidator` elements in `NodeElementBase`. I ensured this change was compatible with XML schema version 1.0.

@bschwind 
Could you test that this PR fixes the problem on your camera, please?




- [x] Check `test_all.sh` is passed.
- [x] Add `fix #{ISSUE_NUMBER}` if the corresponding issue exists.
- [x] Fill out `## Changelog` section. If the change is for only internal use, please write `None` to the section.

## Changelog
[cameleon-genapi] Fix a panic when non-register type nodes have `pInvalidator` element
