### PR TITLE
Disable the camera stream before enabling it

### DIFF
--- a/cameleon/src/u3v/control_handle.rs
+++ b/cameleon/src/u3v/control_handle.rs
@@ -448,6 +448,13 @@ impl DeviceControl for ControlHandle {
     fn enable_streaming(&mut self) -> ControlResult<()> {
         let sirm = unwrap_or_log!(self.sirm());
 
+        // It's forbidden to set SIRM registers while stream is enabled.
+        // This is necessary in case we lost control of a device before properly closing it, which
+        // can happen if the process closes in some way without gracefully terminating.
+        if unwrap_or_log!(sirm.is_stream_enable(self)) {
+            unwrap_or_log!(sirm.disable_stream(self));
+        }
+
         let payload_alignment = unwrap_or_log!(sirm.payload_size_alignment(self));
         macro_rules! align {
             ($expr:expr, $ty: ty) => {


### PR DESCRIPTION
- [ ] Check `test_all.sh` is passed.
- [ ] Add `fix #{ISSUE_NUMBER}` if the corresponding issue exists.
- [x] Fill out `## Changelog` section. If the change is for only internal use, please write `None` to the section.

## Summary
During testing, we noticed if a process is shut down non-gracefully (for example, SIGKILL) while the camera is streaming, subsequent runs of the program fail because calls to `enable_streaming` fail.

We were able to fix this by checking if the stream is enabled, disabling it if it _is_ streaming, and then continue on enabling the stream as normal.

## Note

We ran `test_all.sh` on `main` and the following failed:

```
test src/camera.rs - camera::Camera<Ctrl,Strm,Ctxt>::params_ctxt (line 378) ... FAILED
test src/genapi/mod.rs - genapi (line 8) ... FAILED
test src/genapi/mod.rs - genapi::ParamsCtxt (line 67) ... FAILED
```

These same tests failed on our branch.

We also had to run the test with `RUST_TEST_THREADS=1` because we were getting a few `ControlError(busy)` errors. Rust runs tests in parallel on multiple threads by default so this isn't too surprising, but I'm wondering if you run into the same errors typically?

## Changelog
None