### PR TITLE
Limit test thread

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,2 +1,5 @@
 [target.'cfg(all())']
 rustflags = ["-D", "warnings"]
+
+[env]
+RUST_TEST_THREADS = "1"

--- a/cameleon/src/camera.rs
+++ b/cameleon/src/camera.rs
@@ -341,6 +341,8 @@ impl<Ctrl, Strm, Ctxt> Camera<Ctrl, Strm, Ctxt> {
     /// let payload_rx = camera.start_streaming(3).unwrap();
     ///
     /// camera.stop_streaming().unwrap();
+    ///
+    /// # camera.close().unwrap();
     /// ```
     #[tracing::instrument(skip(self),
                           level = "info",
@@ -405,7 +407,7 @@ impl<Ctrl, Strm, Ctxt> Camera<Ctrl, Strm, Ctxt> {
     /// if gain_node.is_writable(&mut params_ctxt).unwrap() {
     ///     gain_node.set_value(&mut params_ctxt, 0.1).unwrap();
     /// }
-    /// # camera.close();
+    /// # camera.close().unwrap();
     /// ```
     pub fn params_ctxt(&mut self) -> CameleonResult<ParamsCtxt<&mut Ctrl, &mut Ctxt>>
     where

--- a/cameleon/src/genapi/mod.rs
+++ b/cameleon/src/genapi/mod.rs
@@ -12,6 +12,7 @@
 //! #     return;
 //! # }
 //! # let mut camera = cameras.pop().unwrap();
+//! # camera.open().unwrap();
 //! // Loads `GenApi` context.
 //! camera.load_context().unwrap();
 //!
@@ -33,6 +34,8 @@
 //! if gain_node.is_writable(&mut params_ctxt).unwrap() {
 //!     gain_node.set_value(&mut params_ctxt, 0.1).unwrap();
 //! }
+//!
+//! # camera.close().unwrap();
 //! ```
 
 mod node_kind;
@@ -71,6 +74,7 @@ pub use cameleon_genapi::{
 /// #     return;
 /// # }
 /// # let mut camera = cameras.pop().unwrap();
+/// # camera.open().unwrap();
 /// // Loads `GenApi` context.
 /// camera.load_context().unwrap();
 ///
@@ -92,6 +96,8 @@ pub use cameleon_genapi::{
 /// if gain_node.is_writable(&mut params_ctxt).unwrap() {
 ///     gain_node.set_value(&mut params_ctxt, 0.1).unwrap();
 /// }
+///
+/// # camera.close().unwrap();
 /// ```
 #[derive(Debug, Clone)]
 pub struct ParamsCtxt<Ctrl, Ctxt> {


### PR DESCRIPTION
<!--
Thank you for improving `Cameleon`!

Please fill out the checklist before opening the PR.
-->

- [x] Check `test_all.sh` is passed.
- [ ] Add `fix #{ISSUE_NUMBER}` if the corresponding issue exists.
- [x] Fill out `## Changelog` section. If the change is for only internal use, please write `None` to the section.

Ref: `Note` section in #147's PR comment. 

I decided to restrict the number of test threads to one for now so that multiple threads don't open the same camera simultaneously. I don't think this will decrease testing speed so much because there are not so many tests in the library. I'll refine the testing configuration if the testing performance becomes problematic.

<!--
We collect a changelog from a PR description, so please write a brief description about the change in the following `Changelog` section.
-->
## Changelog
None
