### PR TITLE
Fix clippy warnings (casting to the same type)

### DIFF
--- a/cameleon/src/u3v/register_map.rs
+++ b/cameleon/src/u3v/register_map.rs
@@ -793,9 +793,7 @@ impl ManifestTable {
         let entry_num: u64 = self.read_register(device, (0, 8))?;
         let first_entry_addr = self.manifest_address + 8;
 
-        Ok((0..entry_num)
-            .into_iter()
-            .map(move |i| ManifestEntry::new(first_entry_addr + i * 64)))
+        Ok((0..entry_num).map(move |i| ManifestEntry::new(first_entry_addr + i * 64)))
     }
 
     fn read_register<T, Ctrl: DeviceControl + ?Sized>(

--- a/cameleon/src/u3v/stream_handle.rs
+++ b/cameleon/src/u3v/stream_handle.rs
@@ -570,7 +570,7 @@ fn read_trailer<'a>(
     params: &StreamParams,
     buf: &'a mut [u8],
 ) -> StreamResult<u3v_stream::Trailer<'a>> {
-    let trailer_size = params.trailer_size as usize;
+    let trailer_size = params.trailer_size;
     recv(inner, params, buf, trailer_size)?;
 
     u3v_stream::Trailer::parse(buf)

--- a/device/src/u3v/protocol/ack.rs
+++ b/device/src/u3v/protocol/ack.rs
@@ -396,7 +396,7 @@ impl<'a> ParseScd<'a> for WriteMemStacked {
     fn parse(buf: &'a [u8], ccd: &AckCcd) -> Result<Self> {
         let mut cursor = Cursor::new(buf);
         let mut to_read = ccd.scd_len as usize;
-        let mut lengths = Vec::with_capacity(to_read as usize / 4);
+        let mut lengths = Vec::with_capacity(to_read / 4);
 
         while to_read > 0 {
             let reserved: u16 = cursor.read_bytes_le()?;

--- a/genapi/src/masked_int_reg.rs
+++ b/genapi/src/masked_int_reg.rs
@@ -121,7 +121,7 @@ impl IInteger for MaskedIntRegNode {
         let new_reg_value =
             self.bit_mask
                 .masked_value(old_reg_value, value, length, self.endianness, self.sign)?;
-        let mut buf = vec![0; length as usize];
+        let mut buf = vec![0; length];
         utils::bytes_from_int(new_reg_value, &mut buf, self.endianness, self.sign)?;
         reg.write_and_cache(nid, &buf, device, store, cx)?;
 

--- a/impl/tests/macros/wrong_init_array.stderr
+++ b/impl/tests/macros/wrong_init_array.stderr
@@ -4,5 +4,5 @@ error: literal out of range for `u8`
 10 |     ProtocolEndianness = &[0xFF, 1000, 0xFF, 0xFF],
    |                                  ^^^^
    |
-   = note: `#[deny(overflowing_literals)]` on by default
    = note: the literal `1000` does not fit into the type `u8` whose range is `0..=255`
+   = note: `#[deny(overflowing_literals)]` on by default


### PR DESCRIPTION
<!--
Thank you for improving `Cameleon`!

Please fill out the checklist before opening the PR.
-->

- [x] Check `test_all.sh` is passed.
- ~Add `fix #{ISSUE_NUMBER}` if the corresponding issue exists.~
- [x] Fill out `## Changelog` section. If the change is for only internal use, please write `None` to the section.

<!--
We collect a changelog from a PR description, so please write a brief description about the change in the following `Changelog` section.
-->
## Changelog

None