### PR TITLE
Introduce `recv_blocking()` method on `PayloadReceiver`

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,30 +62,28 @@ camera.load_context().unwrap();
 // Start streaming. Channel capacity is set to 3.
 let payload_rx = camera.start_streaming(3).unwrap();
 
-let mut payload_count = 0;
-while payload_count < 10 {
-    match payload_rx.try_recv() {
-        Ok(payload) => {
-            println!(
-                "payload received! block_id: {:?}, timestamp: {:?}",
-                payload.id(),
-                payload.timestamp()
-            );
-            if let Some(image_info) = payload.image_info() {
-                println!("{:?}\n", image_info);
-                let image = payload.image();
-                // do something with the image.
-                // ...
-            }
-            payload_count += 1;
-
-            // Send back payload to streaming loop to reuse the buffer. This is optional.
-            payload_rx.send_back(payload);
-        }
-        Err(_err) => {
+for _ in 0..10 {
+    let payload = match payload_rx.recv_blocking() {
+        Ok(payload) => payload,
+        Err(e) => {
+            println!("payload receive error: {e}");
             continue;
         }
+    };
+    println!(
+        "payload received! block_id: {:?}, timestamp: {:?}",
+        payload.id(),
+        payload.timestamp()
+    );
+    if let Some(image_info) = payload.image_info() {
+        println!("{:?}\n", image_info);
+        let image = payload.image();
+        // do something with the image.
+        // ...
     }
+
+    // Send back payload to streaming loop to reuse the buffer. This is optional.
+    payload_rx.send_back(payload);
 }
 
 // Closes the camera.

--- a/cameleon/Cargo.toml
+++ b/cameleon/Cargo.toml
@@ -20,7 +20,7 @@ thiserror = "1.0.24"
 semver = "1.0.0"
 zip = "0.6.0"
 sha-1 = "0.10.0"
-async-std = { version = "1.9.0", features = ["unstable"] }
+async-std = { version = "1.12.0", features = ["unstable"] }
 tracing = "0.1.26"
 auto_impl = "1.0.1"
 cameleon-device = { path = "../device", version = "0.1.8" }

--- a/cameleon/examples/stream.rs
+++ b/cameleon/examples/stream.rs
@@ -25,27 +25,25 @@ fn main() {
     // Start streaming. Channel capacity is set to 3.
     let payload_rx = camera.start_streaming(3).unwrap();
 
-    let mut payload_count = 0_usize;
-    while payload_count < 10 {
-        match payload_rx.try_recv() {
-            Ok(payload) => {
-                println!(
-                    "payload received! block_id: {:?}, timestamp: {:?}",
-                    payload.id(),
-                    payload.timestamp()
-                );
-                if let Some(image_info) = payload.image_info() {
-                    println!("{:?}\n", image_info);
-                }
-                payload_count += 1;
-
-                // Send back payload to streaming loop to reuse the buffer.
-                payload_rx.send_back(payload);
-            }
-            Err(_err) => {
+    for _ in 0..10 {
+        let payload = match payload_rx.recv_blocking() {
+            Ok(payload) => payload,
+            Err(e) => {
+                println!("payload receive error: {e}");
                 continue;
             }
+        };
+        println!(
+            "payload received! block_id: {:?}, timestamp: {:?}",
+            payload.id(),
+            payload.timestamp()
+        );
+        if let Some(image_info) = payload.image_info() {
+            println!("{:?}\n", image_info);
         }
+
+        // Send back payload to streaming loop to reuse the buffer.
+        payload_rx.send_back(payload);
     }
 
     camera.close().ok();

--- a/cameleon/src/payload.rs
+++ b/cameleon/src/payload.rs
@@ -122,6 +122,12 @@ impl PayloadReceiver {
         self.rx.try_recv()?
     }
 
+    /// Receives [`Payload`] sent from the device.
+    /// If the channel is empty, this method blocks until the device produces the payload.
+    pub fn recv_blocking(&self) -> StreamResult<Payload> {
+        self.rx.recv_blocking()?
+    }
+
     /// Sends back [`Payload`] to the device to reuse already allocated `payload`.
     ///
     /// Sending back `payload` may improve performance of streaming, but not required to call this

--- a/device/Cargo.toml
+++ b/device/Cargo.toml
@@ -10,14 +10,14 @@ repository = "https://github.com/cameleon-rs/cameleon"
 description = """
 cameleon-device provides device specific protocol decoders and basic I/O operations for GenICam compatible devices.
 """
-categories = ["computer-vision"] 
+categories = ["computer-vision"]
 keywords = ["genicam", "camera", "usb3", "gige", "uvc"]
 
 [dependencies]
 thiserror = "1.0.24"
 log = "0.4.14"
 semver = "1.0.0"
-async-std = { version = "1.9.0", features = ["unstable"] }
+async-std = { version = "1.12.0", features = ["unstable"] }
 const_format = "0.2.14"
 futures = "0.3.14"
 lazy_static = "1.4.0"
@@ -28,7 +28,6 @@ cameleon-impl = { path = "../impl", version = "0.1.8" }
 rusb = { version = "0.9.0", optional = true }
 libusb1-sys = { version = "0.6.0", optional = true }
 libc = { version = "0.2", optional = true }
-
 
 [dev-dependencies]
 trybuild = "1.0.42"


### PR DESCRIPTION
Allows callers to wait for a frame without using futures. Turned out [async_channel::Receiver](https://docs.rs/async-channel/latest/async_channel/struct.Receiver.html) already had a [`recv_blocking()`](https://docs.rs/async-channel/latest/async_channel/struct.Receiver.html#method.recv_blocking) method, so this is rather straightforward.

In addition to the API changes, update READMEs and example to use the new method. The version in current `main` does a busy loop (consumes 100% of its CPU thread).

Best viewed with whitespace change ignored.

This is yet to be tested with a real camera (:pray: :pray: @bschwind).

- [x] Check `test_all.sh` is passed.
- ~Add `fix #{ISSUE_NUMBER}` if the corresponding issue exists.~
- [x] Fill out `## Changelog` section. If the change is for only internal use, please write `None` to the section.

<!--
We collect a changelog from a PR description, so please write a brief description about the change in the following `Changelog` section.
-->

## Changelog

- `recv_blocking()` method was introduced on `PayloadReceiver`. It allows callers to wait for a frame without using futures.