### PR TITLE
Use std::mpsc rendezvous channel instead of pair of futures::channels

### DIFF
--- a/cameleon/Cargo.toml
+++ b/cameleon/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/cameleon-rs/cameleon"
 description = """
 cameleon is a safe, fast, and flexible library for GenICam compatible cameras.
 """
-categories = ["computer-vision"] 
+categories = ["computer-vision"]
 keywords = ["genicam", "camera", "usb3", "gige", "uvc"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -21,7 +21,6 @@ semver = "1.0.0"
 zip = "0.6.0"
 sha-1 = "0.10.0"
 async-std = { version = "1.9.0", features = ["unstable"] }
-futures = "0.3.14"
 tracing = "0.1.26"
 auto_impl = "1.0.1"
 cameleon-device = { path = "../device", version = "0.1.8" }


### PR DESCRIPTION
The only use of the (cancellation, completion) channel pair is to synchronize teardown of streaming (either explicitly or when StreamHandle is dropped). This is also the only place where we were spinning and async runtime.

Turns out [`std::sync::mpsc::sync_channel(0)`](https://doc.rust-lang.org/std/sync/mpsc/fn.sync_channel.html) is as special "rendezvous" mode that should do what we want: sends a message and waits for it to be picked up. We also continue to detect StreamHandle drop from the streaming loop.

Should be functionally equivalent, just with less dependencies and without async runtime.

Needs testing.

<!--
Thank you for improving `Cameleon`!

Please fill out the checklist before opening the PR.
-->

- [x] Check `test_all.sh` is passed.
- [x] Add `fix #{ISSUE_NUMBER}` if the corresponding issue exists.
- [x] Fill out `## Changelog` section. If the change is for only internal use, please write `None` to the section.

<!--
We collect a changelog from a PR description, so please write a brief description about the change in the following `Changelog` section.
-->
## Changelog
None