### PR TITLE
Narrow down async-std dependency to async-channel

### DIFF
--- a/cameleon/Cargo.toml
+++ b/cameleon/Cargo.toml
@@ -20,7 +20,7 @@ thiserror = "1.0.24"
 semver = "1.0.0"
 zip = "0.6.0"
 sha-1 = "0.10.0"
-async-std = { version = "1.12.0", features = ["unstable"] }
+async-channel = "1.7.0" # 1.7.0 has added recv_blocking()
 tracing = "0.1.26"
 auto_impl = "1.0.1"
 cameleon-device = { path = "../device", version = "0.1.8" }

--- a/cameleon/src/payload.rs
+++ b/cameleon/src/payload.rs
@@ -11,7 +11,7 @@ pub use cameleon_device::PixelFormat;
 
 use std::time;
 
-use async_std::channel::{Receiver, Sender};
+use async_channel::{Receiver, Sender};
 
 use super::{StreamError, StreamResult};
 
@@ -168,8 +168,8 @@ impl PayloadSender {
 
 /// Creates [`PayloadReceiver`] and [`PayloadSender`].
 pub fn channel(payload_cap: usize, buffer_cap: usize) -> (PayloadSender, PayloadReceiver) {
-    let (device_tx, host_rx) = async_std::channel::bounded(payload_cap);
-    let (host_tx, device_rx) = async_std::channel::bounded(buffer_cap);
+    let (device_tx, host_rx) = async_channel::bounded(payload_cap);
+    let (host_tx, device_rx) = async_channel::bounded(buffer_cap);
     (
         PayloadSender {
             tx: device_tx,
@@ -182,26 +182,26 @@ pub fn channel(payload_cap: usize, buffer_cap: usize) -> (PayloadSender, Payload
     )
 }
 
-impl From<async_std::channel::RecvError> for StreamError {
-    fn from(err: async_std::channel::RecvError) -> Self {
+impl From<async_channel::RecvError> for StreamError {
+    fn from(err: async_channel::RecvError) -> Self {
         StreamError::ReceiveError(err.to_string().into())
     }
 }
 
-impl From<async_std::channel::TryRecvError> for StreamError {
-    fn from(err: async_std::channel::TryRecvError) -> Self {
+impl From<async_channel::TryRecvError> for StreamError {
+    fn from(err: async_channel::TryRecvError) -> Self {
         StreamError::ReceiveError(err.to_string().into())
     }
 }
 
-impl<T> From<async_std::channel::SendError<T>> for StreamError {
-    fn from(err: async_std::channel::SendError<T>) -> Self {
+impl<T> From<async_channel::SendError<T>> for StreamError {
+    fn from(err: async_channel::SendError<T>) -> Self {
         StreamError::ReceiveError(err.to_string().into())
     }
 }
 
-impl<T> From<async_std::channel::TrySendError<T>> for StreamError {
-    fn from(err: async_std::channel::TrySendError<T>) -> Self {
+impl<T> From<async_channel::TrySendError<T>> for StreamError {
+    fn from(err: async_channel::TrySendError<T>) -> Self {
         StreamError::ReceiveError(err.to_string().into())
     }
 }

--- a/device/src/emulator/emulator_impl/memory_event_handler.rs
+++ b/device/src/emulator/emulator_impl/memory_event_handler.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use async_std::channel::{self, Receiver, Sender};
+use async_channel::{self, Receiver, Sender};
 use futures::channel::oneshot;
 
 use cameleon_impl::memory::{prelude::*, MemoryObserver};


### PR DESCRIPTION
Together with #157 this makes cameleon's dependencies much leaner.

Also fixes the minor issue that we previously didn't enforce async-channel version that contained recv_blocking().

<!--
Thank you for improving `Cameleon`!

Please fill out the checklist before opening the PR.
-->

- [x] Check `test_all.sh` is passed.
- [x] Add `fix #{ISSUE_NUMBER}` if the corresponding issue exists.
- [x] Fill out `## Changelog` section. If the change is for only internal use, please write `None` to the section.

<!--
We collect a changelog from a PR description, so please write a brief description about the change in the following `Changelog` section.
-->
## Changelog
None