### PR TITLE
Configure `cargo-release` to use single tag for all crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,6 @@
 [workspace]
 members = ["device", "cameleon", "gentl", "genapi", "impl"]
+
+[workspace.metadata.release]
+# Use single tag for all crates (config for `cargo release`):
+tag-name = "cameleon-v{{version}}"


### PR DESCRIPTION
Closes #159 (I'll cut the release right after merging this).

I'll go ahead and ista-merge this, it just reflects discussion in #159.
