### PR TITLE
Fix swapped use of leader and trailer buffers

### DIFF
--- a/cameleon/src/u3v/stream_handle.rs
+++ b/cameleon/src/u3v/stream_handle.rs
@@ -247,7 +247,7 @@ impl StreamingLoop {
                 },
             };
 
-            let leader = match read_leader(&mut inner, &self.params, &mut trailer_buf) {
+            let leader = match read_leader(&mut inner, &self.params, &mut leader_buf) {
                 Ok(leader) => leader,
                 Err(err) => {
                     // Report and send error if the error is fatal.
@@ -264,7 +264,7 @@ impl StreamingLoop {
                 Some(payload_buf)
             );
             let trailer = unwrap_or_continue!(
-                read_trailer(&mut inner, &self.params, &mut leader_buf),
+                read_trailer(&mut inner, &self.params, &mut trailer_buf),
                 Some(payload_buf)
             );
 


### PR DESCRIPTION
This likely doesn't fix much, but I noticed the use of trailer and leader buffers was swapped. In my testing, the leader and trailer buffers were reported by the camera device to be the same size, which lets this "bug" slip by without causing an issue, but perhaps other cameras have different leader and trailer sizes.

- [x] Check `test_all.sh` is passed.
- [x] Add `fix #{ISSUE_NUMBER}` if the corresponding issue exists.
- [x] Fill out `## Changelog` section. If the change is for only internal use, please write `None` to the section.

<!--
We collect a changelog from a PR description, so please write a brief description about the change in the following `Changelog` section.
-->
## Changelog
None