### PR TITLE
Fix memory leak on `AsyncTransfer` struct

### DIFF
--- a/device/src/u3v/async_read.rs
+++ b/device/src/u3v/async_read.rs
@@ -203,6 +203,9 @@ impl AsyncTransfer {
 impl Drop for AsyncTransfer {
     fn drop(&mut self) {
         unsafe {
+            drop(Box::from_raw(
+                self.transfer().user_data.cast::<AtomicBool>(),
+            ));
             libusb1_sys::libusb_free_transfer(self.ptr.as_ptr());
         }
     }


### PR DESCRIPTION
The `AsyncTransfer` struct was leaking an `AtomicBool`, as it was converted to a raw pointer but never converted back. We found this by using a memory sanitizer (heaptrack) and verified that everything is healthy after the fix.

We have the suspicion that this may fix some unrelated FPS drop issue we've experienced, but we haven't yet verified that. 

- [x] Check `test_all.sh` is passed.
- [x] Add `fix #{ISSUE_NUMBER}` if the corresponding issue exists.
- [x] Fill out `## Changelog` section. If the change is for only internal use, please write `None` to the section.

Fixes tonarino/portal#2283 (tonari's internal issue tracking the mem leak).

<!--
We collect a changelog from a PR description, so please write a brief description about the change in the following `Changelog` section.
-->
## Changelog

None
