### PR TITLE
Use async USB bulk transfers for leader and trailer buffers

### DIFF
--- a/cameleon/src/lib.rs
+++ b/cameleon/src/lib.rs
@@ -198,8 +198,8 @@ pub enum ControlError {
     #[error("input/output error: {0}")]
     Io(anyhow::Error),
 
-    /// Timeout has occured when receiveing stream payload.
-    #[error("timeout has occured when receiveing stream payload")]
+    /// Timeout has occured when receiving stream payload.
+    #[error("timeout has occured when receiving stream payload")]
     Timeout,
 
     /// The device is not opened.
@@ -246,8 +246,8 @@ pub enum StreamError {
     #[error("can't communicate with the device: {0}")]
     Io(anyhow::Error),
 
-    /// Timeout has occured when receiveing stream payload.
-    #[error("timeout has occured when receiveing stream payload")]
+    /// Timeout has occured when receiving stream payload.
+    #[error("timeout has occured when receiving stream payload")]
     Timeout,
 
     /// A panic has occurred in streaming loop.

--- a/cameleon/src/u3v/stream_handle.rs
+++ b/cameleon/src/u3v/stream_handle.rs
@@ -7,7 +7,7 @@
 use std::{
     convert::TryInto,
     sync::mpsc,
-    sync::{mpsc::TryRecvError, Arc, Mutex, MutexGuard},
+    sync::{mpsc::TryRecvError, Arc, Mutex},
     time::Duration,
 };
 
@@ -42,47 +42,13 @@ macro_rules! unwrap_or_poisoned {
 }
 
 impl StreamHandle {
-    /// Read leader of a stream packet.
-    ///
-    /// Buffer size must be equal or larger than [`StreamParams::leader_size`].
-    pub fn read_leader<'a>(&self, buf: &'a mut [u8]) -> StreamResult<u3v_stream::Leader<'a>> {
-        if self.is_loop_running() {
-            Err(StreamError::InStreaming)
-        } else {
-            read_leader(
-                &mut unwrap_or_poisoned!(self.inner.lock())?,
-                &self.params,
-                buf,
-            )
-        }
-    }
-
-    /// Read payload of a stream packet.
-    pub fn read_payload(&self, buf: &mut [u8]) -> StreamResult<usize> {
-        if self.is_loop_running() {
-            Err(StreamError::InStreaming)
-        } else {
-            read_payload(
-                &mut unwrap_or_poisoned!(self.inner.lock())?,
-                &self.params,
-                buf,
-            )
-        }
-    }
-
-    /// Read trailer of a stream packet.
-    ///
-    /// Buffer size must be equal of larger than [`StreamParams::trailer_size`].
-    pub fn read_trailer<'a>(&self, buf: &'a mut [u8]) -> StreamResult<u3v_stream::Trailer<'a>> {
-        if self.is_loop_running() {
-            Err(StreamError::InStreaming)
-        } else {
-            read_trailer(
-                &mut unwrap_or_poisoned!(self.inner.lock())?,
-                &self.params,
-                buf,
-            )
-        }
+    pub(super) fn new(device: &u3v::Device) -> ControlResult<Option<Self>> {
+        let inner = device.stream_channel()?;
+        Ok(inner.map(|inner| Self {
+            inner: Arc::new(Mutex::new(inner)),
+            params: StreamParams::default(),
+            cancellation_tx: None,
+        }))
     }
 
     /// Return params.
@@ -94,15 +60,6 @@ impl StreamHandle {
     ///  Return mutable params.
     pub fn params_mut(&mut self) -> &mut StreamParams {
         &mut self.params
-    }
-
-    pub(super) fn new(device: &u3v::Device) -> ControlResult<Option<Self>> {
-        let inner = device.stream_channel()?;
-        Ok(inner.map(|inner| Self {
-            inner: Arc::new(Mutex::new(inner)),
-            params: StreamParams::default(),
-            cancellation_tx: None,
-        }))
     }
 }
 
@@ -205,7 +162,7 @@ impl StreamingLoop {
         let mut trailer_buf = vec![0; self.params.trailer_size];
         let mut payload_buf_opt = None;
         let mut leader_buf = vec![0; self.params.leader_size];
-        let mut inner = self.inner.lock().unwrap();
+        let inner = self.inner.lock().unwrap();
 
         loop {
             // Stop the loop when
@@ -232,37 +189,77 @@ impl StreamingLoop {
                 },
             };
 
-            let leader = match read_leader(&mut inner, &self.params, &mut leader_buf) {
+            let mut async_pool = AsyncPool::new(&inner);
+
+            if let Err(err) = read_leader(&mut async_pool, &self.params, &mut leader_buf) {
+                // Report and send error if the error is fatal.
+                if matches!(err, StreamError::Io(..) | StreamError::Disconnected) {
+                    error!(?err);
+                    self.sender.try_send(Err(err)).ok();
+                }
+                payload_buf_opt = Some(payload_buf);
+                continue;
+            };
+
+            if let Err(err) = read_payload(&mut async_pool, &self.params, &mut payload_buf) {
+                warn!(?err);
+                // Reuse `payload_buf`.
+                payload_buf_opt = Some(payload_buf);
+                self.sender.try_send(Err(err)).ok();
+                continue;
+            };
+
+            if let Err(err) = read_trailer(&mut async_pool, &self.params, &mut trailer_buf) {
+                warn!(?err);
+                // Reuse `payload_buf`.
+                payload_buf_opt = Some(payload_buf);
+                self.sender.try_send(Err(err)).ok();
+                continue;
+            };
+
+            // We've submitted the bulk transfers, now wait for them.
+            let mut read_lengths = vec![]; // TODO(bschwind) - Probably don't need a vec for this.
+
+            while !async_pool.is_empty() {
+                let len = match async_pool.poll(self.params.timeout) {
+                    Ok(len) => len,
+                    Err(err) => {
+                        warn!(?err);
+                        // Can't reuse `payload_buf` because we're in a loop.
+                        payload_buf_opt = None;
+                        self.sender.try_send(Err(err.into())).ok();
+                        continue;
+                    }
+                };
+
+                read_lengths.push(len);
+            }
+
+            let read_payload_size = read_lengths[1..(read_lengths.len() - 1)].iter().sum();
+
+            // We received the data from the bulk transfers, try to parse stuff now.
+            let leader = match u3v_stream::Leader::parse(&leader_buf)
+                .map_err(|e| StreamError::InvalidPayload(format!("{}", e).into()))
+            {
                 Ok(leader) => leader,
                 Err(err) => {
-                    // Report and send error if the error is fatal.
-                    if matches!(err, StreamError::Io(..) | StreamError::Disconnected) {
-                        error!(?err);
-                        self.sender.try_send(Err(err)).ok();
-                    }
-                    payload_buf_opt = Some(payload_buf);
-                    continue;
-                }
-            };
-
-            let read_payload_size = match read_payload(&mut inner, &self.params, &mut payload_buf) {
-                Ok(size) => size,
-                Err(e) => {
-                    warn!(?e);
+                    warn!(?err);
                     // Reuse `payload_buf`.
                     payload_buf_opt = Some(payload_buf);
-                    self.sender.try_send(Err(e)).ok();
+                    self.sender.try_send(Err(err)).ok();
                     continue;
                 }
             };
 
-            let trailer = match read_trailer(&mut inner, &self.params, &mut trailer_buf) {
+            let trailer = match u3v_stream::Trailer::parse(&trailer_buf)
+                .map_err(|e| StreamError::InvalidPayload(format!("invalid trailer: {}", e).into()))
+            {
                 Ok(trailer) => trailer,
-                Err(e) => {
-                    warn!(?e);
+                Err(err) => {
+                    warn!(?err);
                     // Reuse `payload_buf`.
                     payload_buf_opt = Some(payload_buf);
-                    self.sender.try_send(Err(e)).ok();
+                    self.sender.try_send(Err(err)).ok();
                     continue;
                 }
             };
@@ -521,24 +518,23 @@ impl StreamParams {
     }
 }
 
-fn read_leader<'a>(
-    inner: &mut MutexGuard<'_, u3v::ReceiveChannel>,
+fn read_leader(
+    async_pool: &mut AsyncPool,
     params: &StreamParams,
-    buf: &'a mut [u8],
-) -> StreamResult<u3v_stream::Leader<'a>> {
+    buf: &mut [u8],
+) -> StreamResult<()> {
     let leader_size = params.leader_size;
-    recv(inner, params, buf, leader_size)?;
+    async_pool.submit(&mut buf[..leader_size])?;
 
-    u3v_stream::Leader::parse(buf).map_err(|e| StreamError::InvalidPayload(format!("{}", e).into()))
+    Ok(())
 }
 
 fn read_payload(
-    inner: &mut MutexGuard<'_, u3v::ReceiveChannel>,
+    async_pool: &mut AsyncPool,
     params: &StreamParams,
     buf: &mut [u8],
-) -> StreamResult<usize> {
+) -> StreamResult<()> {
     let payload_size = params.payload_size;
-    let mut async_pool = AsyncPool::new(inner);
     let mut cursor = 0;
     for _ in 0..params.payload_count {
         async_pool.submit(&mut buf[cursor..cursor + payload_size])?;
@@ -553,41 +549,16 @@ fn read_payload(
         async_pool.submit(&mut buf[cursor..cursor + params.payload_final2_size])?;
     }
 
-    let mut read_len = 0;
-    while !async_pool.is_empty() {
-        read_len += async_pool.poll(params.timeout)?;
-    }
-
-    Ok(read_len)
+    Ok(())
 }
 
-fn read_trailer<'a>(
-    inner: &mut MutexGuard<'_, u3v::ReceiveChannel>,
-    params: &StreamParams,
-    buf: &'a mut [u8],
-) -> StreamResult<u3v_stream::Trailer<'a>> {
-    let trailer_size = params.trailer_size;
-    recv(inner, params, buf, trailer_size)?;
-
-    u3v_stream::Trailer::parse(buf)
-        .map_err(|e| StreamError::InvalidPayload(format!("invalid trailer: {}", e).into()))
-}
-
-fn recv(
-    inner: &mut MutexGuard<'_, u3v::ReceiveChannel>,
+fn read_trailer(
+    async_pool: &mut AsyncPool,
     params: &StreamParams,
     buf: &mut [u8],
-    len: usize,
-) -> StreamResult<usize> {
-    if len == 0 {
-        return Ok(0);
-    }
+) -> StreamResult<()> {
+    let trailer_size = params.trailer_size;
+    async_pool.submit(&mut buf[..trailer_size])?;
 
-    if buf.len() < len {
-        return Err(StreamError::BufferTooSmall);
-    }
-
-    inner
-        .recv(&mut buf[..len], params.timeout)
-        .map_err(|e| e.into())
+    Ok(())
 }

--- a/cameleon/src/u3v/stream_handle.rs
+++ b/cameleon/src/u3v/stream_handle.rs
@@ -164,7 +164,7 @@ impl StreamingLoop {
         let mut leader_buf = vec![0; self.params.leader_size];
         let inner = self.inner.lock().unwrap();
 
-        loop {
+        'outer: loop {
             // Stop the loop when
             // 1. `cancellation_tx` sends signal.
             // 2. `cancellation_tx` is dropped.
@@ -230,7 +230,7 @@ impl StreamingLoop {
                         // Can't reuse `payload_buf` because we're in a loop.
                         payload_buf_opt = None;
                         self.sender.try_send(Err(err.into())).ok();
-                        continue;
+                        continue 'outer;
                     }
                 };
 

--- a/cameleon/src/u3v/stream_handle.rs
+++ b/cameleon/src/u3v/stream_handle.rs
@@ -228,7 +228,6 @@ impl StreamingLoop {
                     Err(err) => {
                         warn!(?err);
                         // Can't reuse `payload_buf` because we're in a loop.
-                        payload_buf_opt = None;
                         self.sender.try_send(Err(err.into())).ok();
                         continue 'outer;
                     }
@@ -236,11 +235,11 @@ impl StreamingLoop {
 
                 if first_buf_len.is_none() {
                     first_buf_len = Some(len);
-                    last_buf_len = Some(len);
                 } else {
-                    last_buf_len = Some(len);
                     payload_len += len;
                 }
+
+                last_buf_len = Some(len);
             }
 
             let payload_len = payload_len - last_buf_len.unwrap();


### PR DESCRIPTION
Fixes #156

This changes the U3V capture loop to use async bulk transfers for the leader and trailer buffers, as well as the payload buffers.

Async was already used for the payload buffers, but the leader and trailer buffers were read synchronously. My guess is the synchronous read of a leader buffer caused the camera we were testing in #156 to start sending data, and with the synchronous nature of bulk transfers, our timing may have been delayed which lead to `DataDiscarded` errors when reading the actual frame payloads.

With this change, we queue up _all_ bulk transfers at once so the bus is continuously able to transfer data without having to wait for our code to issue more reads. This should result in a more stable operation, possibly lower latency, and possibly the capability to transfer more data per frame.

This should be tested on several different Genicam-enabled cameras.

- [x] Check `test_all.sh` is passed.
- [x] Add `fix #{ISSUE_NUMBER}` if the corresponding issue exists.
- [x] Fill out `## Changelog` section. If the change is for only internal use, please write `None` to the section.

## Changelog
* Improved stability of frame capture by only using async USB bulk transfers for frame payloads