### PR TITLE
Allow implicit cast between (GenICam) int, float, and enum

### DIFF
--- a/device/src/u3v/async_read.rs
+++ b/device/src/u3v/async_read.rs
@@ -217,7 +217,7 @@ impl Drop for AsyncTransfer {
 /// timeout, or error, instead of potentially returning early.
 ///
 /// This design is based on
-/// https://libusb.sourceforge.io/api-1.0/libusb_mtasync.html#threadwait
+/// <https://libusb.sourceforge.io/api-1.0/libusb_mtasync.html#threadwait>
 fn poll_completed(
     ctx: &impl UsbContext,
     timeout: Duration,

--- a/genapi/src/boolean.rs
+++ b/genapi/src/boolean.rs
@@ -65,7 +65,7 @@ impl IBoolean for BooleanNode {
         store: &impl NodeStore,
         cx: &mut ValueCtxt<T, U>,
     ) -> GenApiResult<bool> {
-        let value = self.value.value(device, store, cx)?;
+        let value: i64 = self.value.value(device, store, cx)?;
         if value == self.on_value {
             Ok(true)
         } else if value == self.off_value {
@@ -102,7 +102,7 @@ impl IBoolean for BooleanNode {
         cx: &mut ValueCtxt<T, U>,
     ) -> GenApiResult<bool> {
         Ok(self.elem_base.is_readable(device, store, cx)?
-            && self.value.is_readable(device, store, cx)?)
+            && IValue::<i64>::is_readable(&self.value, device, store, cx)?)
     }
 
     #[tracing::instrument(skip(self, device, store, cx),
@@ -115,7 +115,7 @@ impl IBoolean for BooleanNode {
         cx: &mut ValueCtxt<T, U>,
     ) -> GenApiResult<bool> {
         Ok(self.elem_base.is_writable(device, store, cx)?
-            && self.value.is_writable(device, store, cx)?)
+            && IValue::<i64>::is_writable(&self.value, device, store, cx)?)
     }
 }
 

--- a/genapi/src/elem_type.rs
+++ b/genapi/src/elem_type.rs
@@ -6,7 +6,6 @@
 use std::marker::PhantomData;
 
 use super::{
-    interface::IInteger,
     ivalue::IValue,
     store::{CacheStore, NodeId, NodeStore, ValueStore},
     Device, GenApiResult, ValueCtxt,
@@ -281,7 +280,7 @@ impl AddressKind {
     ) -> GenApiResult<i64> {
         match self {
             Self::Address(i) => i.value(device, store, cx),
-            Self::IntSwissKnife(nid) => nid.expect_iinteger_kind(store)?.value(device, store, cx),
+            Self::IntSwissKnife(nid) => nid.value(device, store, cx),
             Self::PIndex(p_index) => p_index.value(device, store, cx),
         }
     }
@@ -310,12 +309,10 @@ impl RegPIndex {
         store: &impl NodeStore,
         cx: &mut ValueCtxt<T, U>,
     ) -> GenApiResult<i64> {
-        let base = self
-            .p_index
-            .expect_iinteger_kind(store)?
-            .value(device, store, cx)?;
+        let base = self.p_index.value(device, store, cx)?;
         if let Some(offset) = &self.offset {
-            Ok(base + offset.value(device, store, cx)?)
+            let offset: i64 = offset.value(device, store, cx)?;
+            Ok(base + offset)
         } else {
             Ok(base)
         }

--- a/genapi/src/enumeration.rs
+++ b/genapi/src/enumeration.rs
@@ -152,7 +152,7 @@ impl IEnumeration for EnumerationNode {
         cx: &mut ValueCtxt<T, U>,
     ) -> GenApiResult<bool> {
         Ok(self.elem_base.is_readable(device, store, cx)?
-            && self.value.is_readable(device, store, cx)?)
+            && IValue::<i64>::is_readable(&self.value, device, store, cx)?)
     }
 
     #[tracing::instrument(skip(self, device, store, cx),
@@ -165,7 +165,7 @@ impl IEnumeration for EnumerationNode {
         cx: &mut ValueCtxt<T, U>,
     ) -> GenApiResult<bool> {
         Ok(self.elem_base.is_writable(device, store, cx)?
-            && self.value.is_writable(device, store, cx)?)
+            && IValue::<i64>::is_writable(&self.value, device, store, cx)?)
     }
 }
 

--- a/genapi/src/float.rs
+++ b/genapi/src/float.rs
@@ -198,7 +198,7 @@ impl IFloat for FloatNode {
         cx: &mut ValueCtxt<T, U>,
     ) -> GenApiResult<bool> {
         Ok(self.elem_base.is_readable(device, store, cx)?
-            && self.value_kind.is_readable(device, store, cx)?)
+            && IValue::<f64>::is_readable(&self.value_kind, device, store, cx)?)
     }
 
     #[tracing::instrument(skip(self, device, store, cx),
@@ -211,6 +211,6 @@ impl IFloat for FloatNode {
         cx: &mut ValueCtxt<T, U>,
     ) -> GenApiResult<bool> {
         Ok(self.elem_base.is_writable(device, store, cx)?
-            && self.value_kind.is_writable(device, store, cx)?)
+            && IValue::<f64>::is_writable(&self.value_kind, device, store, cx)?)
     }
 }

--- a/genapi/src/integer.rs
+++ b/genapi/src/integer.rs
@@ -188,7 +188,7 @@ impl IInteger for IntegerNode {
         cx: &mut ValueCtxt<T, U>,
     ) -> GenApiResult<bool> {
         Ok(self.elem_base.is_readable(device, store, cx)?
-            && self.value_kind.is_readable(device, store, cx)?)
+            && IValue::<i64>::is_readable(&self.value_kind, device, store, cx)?)
     }
 
     #[tracing::instrument(skip(self, device, store, cx),
@@ -201,7 +201,7 @@ impl IInteger for IntegerNode {
         cx: &mut ValueCtxt<T, U>,
     ) -> GenApiResult<bool> {
         Ok(self.elem_base.is_writable(device, store, cx)?
-            && self.value_kind.is_writable(device, store, cx)?)
+            && IValue::<i64>::is_writable(&self.value_kind, device, store, cx)?)
     }
 }
 

--- a/genapi/src/store.rs
+++ b/genapi/src/store.rs
@@ -87,23 +87,32 @@ pub trait ValueStore {
         self.value_opt(id).unwrap()
     }
 
-    fn integer_value(&self, id: IntegerId) -> Option<i64> {
-        if let ValueData::Integer(i) = self.value_opt(id)? {
-            Some(*i)
-        } else {
-            None
+    fn integer_value<T>(&self, id: T) -> Option<i64>
+    where
+        T: Into<ValueId>,
+    {
+        match self.value_opt(id)? {
+            ValueData::Integer(i) => Some(*i),
+            ValueData::Float(f) => Some(*f as i64),
+            _ => None,
         }
     }
 
-    fn float_value(&self, id: FloatId) -> Option<f64> {
-        if let ValueData::Float(f) = self.value_opt(id)? {
-            Some(*f)
-        } else {
-            None
+    fn float_value<T>(&self, id: T) -> Option<f64>
+    where
+        T: Into<ValueId>,
+    {
+        match self.value_opt(id)? {
+            ValueData::Integer(i) => Some(*i as f64),
+            ValueData::Float(f) => Some(*f),
+            _ => None,
         }
     }
 
-    fn str_value(&self, id: StringId) -> Option<&String> {
+    fn str_value<T>(&self, id: T) -> Option<&String>
+    where
+        T: Into<ValueId>,
+    {
         if let ValueData::Str(s) = self.value_opt(id)? {
             Some(s)
         } else {


### PR DESCRIPTION
<!--
Thank you for improving `Cameleon`!

Please fill out the checklist before opening the PR.
-->

- [x] Check `test_all.sh` is passed.
- [x] Add fix #168, fix #98
- [x] Fill out `## Changelog` section. If the change is for only internal use, please write `None` to the section.

<!--
We collect a changelog from a PR description, so please write a brief description about the change in the following `Changelog` section.
-->
This change allows an implicit casting between int, float, and enum types when the GenApi context requires this kind of casting. 
NOTE: This change doesn't affect the public API.