### PR TITLE
Fix clippy 1.73 lints (trivial)

### DIFF
--- a/genapi/src/port.rs
+++ b/genapi/src/port.rs
@@ -62,9 +62,7 @@ impl IPort for PortNode {
         if self.chunk_id.is_some() {
             Err(GenApiError::chunk_data_missing())
         } else {
-            device
-                .read_mem(address, buf)
-                .map_err(|e| GenApiError::device(e))
+            device.read_mem(address, buf).map_err(GenApiError::device)
         }
     }
 
@@ -85,9 +83,7 @@ impl IPort for PortNode {
             // TODO: Implement chunk parser.
             todo!()
         } else {
-            device
-                .write_mem(address, buf)
-                .map_err(|e| GenApiError::device(e))
+            device.write_mem(address, buf).map_err(GenApiError::device)
         }
     }
 }


### PR DESCRIPTION
<!--
Thank you for improving `Cameleon`!

Please fill out the checklist before opening the PR.
-->

- [x] Check `test_all.sh` is passed.
- [x] Add `fix #{ISSUE_NUMBER}` if the corresponding issue exists.
- [x] Fill out `## Changelog` section. If the change is for only internal use, please write `None` to the section.

BTW the `rustflags = ["-D", "warnings"]` in https://github.com/cameleon-rs/cameleon/blob/main/.cargo/config might a bit too strict: it prevents from compiling code with warnings during development iterations.

More canonical would be to do a following change to https://github.com/cameleon-rs/cameleon/blob/main/.github/workflows/ci.yml:
```diff
-        run: cargo clippy --workspace --all-targets --all-features -- -D clippy::all
+        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
```
(which catches both rustc and clippy warnings)

<!--
We collect a changelog from a PR description, so please write a brief description about the change in the following `Changelog` section.
-->
## Changelog
None