### PR TITLE
Bugfix in register_base.rs

### DIFF
--- a/genapi/src/register_base.rs
+++ b/genapi/src/register_base.rs
@@ -76,7 +76,7 @@ impl RegisterBase {
     ) -> GenApiResult<R> {
         let length = self.length(device, store, cx)?;
         let address = self.address(device, store, cx)?;
-        if let Some(cache) = cx.get_cache(nid, length, address) {
+        if let Some(cache) = cx.get_cache(nid, address, length) {
             f(cache)
         } else {
             let mut buf = vec![0; length as usize];


### PR DESCRIPTION
Function parameters were out of order

<!--
Thank you for improving `Cameleon`!

Please fill out the checklist before opening the PR.
-->

- [x] Check `test_all.sh` is passed.
- [x] Add `fix #{ISSUE_NUMBER}` if the corresponding issue exists.
- [x] Fill out `## Changelog` section. If the change is for only internal use, please write `None` to the section.

<!--
We collect a changelog from a PR description, so please write a brief description about the change in the following `Changelog` section.
-->
## Changelog

Bugfix in register_base.rs::with_cache_or_read: Function parameters were out of order.