### PR TITLE
Offset calculation is multiplicative in GenICam + Default for increment in Integer Nodes

### DIFF
--- a/genapi/src/elem_type.rs
+++ b/genapi/src/elem_type.rs
@@ -312,7 +312,7 @@ impl RegPIndex {
         let base = self.p_index.value(device, store, cx)?;
         if let Some(offset) = &self.offset {
             let offset: i64 = offset.value(device, store, cx)?;
-            Ok(base + offset)
+            Ok(base * offset)
         } else {
             Ok(base)
         }

--- a/genapi/src/parser/integer.rs
+++ b/genapi/src/parser/integer.rs
@@ -45,7 +45,7 @@ impl Parse for IntegerNode {
         let inc = node
             .parse_if(INC, node_builder, value_builder, cache_builder)
             .or_else(|| node.parse_if(P_INC, node_builder, value_builder, cache_builder))
-            .unwrap_or(ImmOrPNode::Imm(10));
+            .unwrap_or(ImmOrPNode::Imm(1));
         let unit = node.parse_if(UNIT, node_builder, value_builder, cache_builder);
         let representation: IntegerRepresentation = node
             .parse_if(REPRESENTATION, node_builder, value_builder, cache_builder)


### PR DESCRIPTION
- [x] Check `test_all.sh` is passed.
- [x] Add `fix #{ISSUE_NUMBER}` if the corresponding issue exists.
- [x] Fill out `## Changelog` section. If the change is for only internal use, please write `None` to the section.

## Changelog
Bugfix: The **product** of _Offset_ and _Index_ need to be added to the address for address offset calculations.
Bugfix: Default increment for Integer Nodes is 1.