### PR TITLE
Fix lints introduced by clippy 1.78 to 1.80

### DIFF
--- a/cameleon/src/u3v/control_handle.rs
+++ b/cameleon/src/u3v/control_handle.rs
@@ -36,7 +36,7 @@ const INITIAL_MAXIMUM_ACK_LENGTH: u32 = 128;
 const PAYLOAD_TRANSFER_SIZE: u32 = 1024 * 64;
 
 /// This handle provides low level API to read and write data from the device.  
-/// See [`ControlHandle::abrm`] and [`register_map`](super::register_map) which provide more
+/// See [`ControlHandle::abrm`] and [`register_map`] which provide more
 /// convenient way to communicate with `u3v` specific registers.
 ///
 /// # Examples

--- a/genapi/src/masked_int_reg.rs
+++ b/genapi/src/masked_int_reg.rs
@@ -378,7 +378,7 @@ impl BitMask {
         match sign {
             Sign::Signed => {
                 if msb - lsb == 63 {
-                    std::i64::MIN
+                    i64::MIN
                 } else {
                     let value = 1 << (msb - lsb) as i64;
                     -value
@@ -394,13 +394,13 @@ impl BitMask {
             self.msb(reg_byte_len, endianness),
         );
         if msb - lsb == 63 {
-            return std::i64::MAX;
+            return i64::MAX;
         }
         match sign {
             Sign::Signed => (1 << (msb - lsb)) - 1,
             Sign::Unsigned => {
                 if msb - lsb == 63 {
-                    std::i64::MAX
+                    i64::MAX
                 } else {
                     (1 << (msb - lsb + 1)) - 1
                 }
@@ -517,7 +517,7 @@ mod tests {
 
         let sign = Sign::Unsigned;
         assert_eq!(mask.min(reg_len, endianness, sign), 0);
-        assert_eq!(mask.max(reg_len, endianness, sign), std::i64::MAX);
+        assert_eq!(mask.max(reg_len, endianness, sign), i64::MAX);
         let value = mask.apply_mask(reg_value, reg_len, endianness, sign);
         assert_eq!(value, i64::MAX);
         let new_value = mask
@@ -526,13 +526,13 @@ mod tests {
         assert_eq!(new_value, 0);
 
         let sign = Sign::Signed;
-        assert_eq!(mask.min(reg_len, endianness, sign), std::i64::MIN);
-        assert_eq!(mask.max(reg_len, endianness, sign), std::i64::MAX);
+        assert_eq!(mask.min(reg_len, endianness, sign), i64::MIN);
+        assert_eq!(mask.max(reg_len, endianness, sign), i64::MAX);
         let value = mask.apply_mask(reg_value, reg_len, endianness, sign);
-        assert_eq!(value, std::i64::MAX);
+        assert_eq!(value, i64::MAX);
         let new_value = mask
-            .masked_value(reg_value, std::i64::MIN, reg_len, endianness, sign)
+            .masked_value(reg_value, i64::MIN, reg_len, endianness, sign)
             .unwrap();
-        assert_eq!(new_value, std::i64::MIN);
+        assert_eq!(new_value, i64::MIN);
     }
 }

--- a/genapi/src/parser/elem_type.rs
+++ b/genapi/src/parser/elem_type.rs
@@ -473,7 +473,7 @@ impl Parse for NodeId {
         _: &mut impl CacheStoreBuilder,
     ) -> Self {
         let text = node.next_text().unwrap();
-        node_builder.get_or_intern(&text.view())
+        node_builder.get_or_intern(text.view())
     }
 }
 

--- a/genapi/src/parser/port.rs
+++ b/genapi/src/parser/port.rs
@@ -32,7 +32,7 @@ impl Parse for PortNode {
         let chunk_id = node.next_if(CHUNK_ID).map_or_else(
             || {
                 node.next_if(P_CHUNK_ID).map(|next_node| {
-                    ImmOrPNode::PNode(node_builder.get_or_intern(&next_node.text().view()))
+                    ImmOrPNode::PNode(node_builder.get_or_intern(next_node.text().view()))
                 })
             },
             |next_node| {

--- a/genapi/src/parser/string.rs
+++ b/genapi/src/parser/string.rs
@@ -33,7 +33,7 @@ impl Parse for StringNode {
             .parse_if(STREAMABLE, node_builder, value_builder, cache_builder)
             .unwrap_or_default();
         let value = node.next_if(VALUE).map_or_else(
-            || ImmOrPNode::PNode(node_builder.get_or_intern(&node.next_text().unwrap().view())),
+            || ImmOrPNode::PNode(node_builder.get_or_intern(node.next_text().unwrap().view())),
             |next_node| {
                 let id = value_builder.store(next_node.text().view().into_owned());
                 ImmOrPNode::Imm(id)

--- a/genapi/src/store.rs
+++ b/genapi/src/store.rs
@@ -522,7 +522,7 @@ impl CacheStore for DefaultCacheStore {
             .and_modify(|level1| {
                 level1
                     .entry((address, length))
-                    .and_modify(|level2| *level2 = data.to_owned())
+                    .and_modify(|level2| data.clone_into(level2))
                     .or_insert_with(|| data.to_owned());
             })
             .or_insert_with(|| {


### PR DESCRIPTION
<!--
Thank you for improving `Cameleon`!

Please fill out the checklist before opening the PR.
-->

- [ ] Check `test_all.sh` is passed: Hmm, they don't. I'm getting:
  ```
  test examples/u3v/register_map.rs ... error
  Test case failed at runtime.
  
  STDERR:
  ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
  warning: `/home/strohel/work/cameleon/.cargo/config` is deprecated in favor of `config.toml`
  note: if you need to support cargo 1.38 or earlier, you can symlink `config` to `config.toml`
  thread 'main' panicked at library/core/src/panicking.rs:220:5:
  unsafe precondition(s) violated: slice::from_raw_parts requires the pointer to be aligned and non-null, and the total size of the slice not to exceed `isize::MAX`
  stack backtrace:
     0: rust_begin_unwind
     1: core::panicking::panic_nounwind_fmt
     2: core::panicking::panic_nounwind
     3: core::slice::raw::from_raw_parts::precondition_check
               at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/core/src/ub_checks.rs:66:21
     4: core::slice::raw::from_raw_parts
               at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/core/src/ub_checks.rs:73:17
     5: rusb::interface_descriptor::InterfaceDescriptor::endpoint_descriptors
               at /home/strohel/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rusb-0.9.3/src/interface_descriptor.rs:95:13
     6: cameleon_device::u3v::device_builder::DeviceBuilder::find_u3v_iad_in_if_desc
               at /home/strohel/work/cameleon/device/src/u3v/device_builder.rs:166:24
     7: cameleon_device::u3v::device_builder::DeviceBuilder::find_u3v_iad_in_config_desc
               at /home/strohel/work/cameleon/device/src/u3v/device_builder.rs:150:40
     8: cameleon_device::u3v::device_builder::DeviceBuilder::find_u3v_iad
               at /home/strohel/work/cameleon/device/src/u3v/device_builder.rs:133:36
     9: cameleon_device::u3v::device_builder::DeviceBuilder::new
               at /home/strohel/work/cameleon/device/src/u3v/device_builder.rs:50:45
    10: cameleon_device::u3v::device_builder::enumerate_devices::{{closure}}
               at /home/strohel/work/cameleon/device/src/u3v/device_builder.rs:29:27
    11: core::iter::adapters::filter_map::filter_map_try_fold::{{closure}}
               at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/core/src/iter/adapters/filter_map.rs:49:28
    12: core::iter::traits::iterator::Iterator::try_fold
               at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/core/src/iter/traits/iterator.rs:2410:21
    13: <core::iter::adapters::filter_map::FilterMap<I,F> as core::iter::traits::iterator::Iterator>::try_fold
               at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/core/src/iter/adapters/filter_map.rs:140:9
    14: core::iter::traits::iterator::Iterator::find_map
               at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/core/src/iter/traits/iterator.rs:2912:9
    15: <core::iter::adapters::filter_map::FilterMap<I,F> as core::iter::traits::iterator::Iterator>::next
               at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/core/src/iter/adapters/filter_map.rs:64:9
    16: <alloc::vec::Vec<T> as alloc::vec::spec_from_iter_nested::SpecFromIterNested<T,I>>::from_iter
               at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/alloc/src/vec/spec_from_iter_nested.rs:26:32
    17: <alloc::vec::Vec<T> as alloc::vec::spec_from_iter::SpecFromIter<T,I>>::from_iter
               at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/alloc/src/vec/spec_from_iter.rs:33:9
    18: <alloc::vec::Vec<T> as core::iter::traits::collect::FromIterator<T>>::from_iter
               at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/alloc/src/vec/mod.rs:2972:9
    19: core::iter::traits::iterator::Iterator::collect
               at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/core/src/iter/traits/iterator.rs:2004:9
    20: cameleon_device::u3v::device_builder::enumerate_devices
               at /home/strohel/work/cameleon/device/src/u3v/device_builder.rs:31:8
    21: cameleon::u3v::enumerate_cameras
               at /home/strohel/work/cameleon/cameleon/src/u3v/mod.rs:76:19
    22: trybuild000::main
               at /home/strohel/work/cameleon/cameleon/examples/u3v/register_map.rs:11:23
    23: core::ops::function::FnOnce::call_once
               at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/core/src/ops/function.rs:250:5
  note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
  thread caused non-unwinding panic. aborting.
  ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
  ```
  Looks like unrelated possibly safety issue?
- [x] Add `fix #{ISSUE_NUMBER}` if the corresponding issue exists.
- [x] Fill out `## Changelog` section. If the change is for only internal use, please write `None` to the section.

<!--
We collect a changelog from a PR description, so please write a brief description about the change in the following `Changelog` section.
-->
## Changelog
None