### PR TITLE
Bump libusb1-sys to allow newest rusb

### DIFF
--- a/device/Cargo.toml
+++ b/device/Cargo.toml
@@ -21,7 +21,7 @@ cfg-if = "1.0.0"
 cameleon-impl = { path = "../impl", version = "0.1.12" }
 
 rusb = { version = "0.9.0", optional = true }
-libusb1-sys = { version = "0.6.0", optional = true }
+libusb1-sys = { version = "0.7.0", optional = true }
 libc = { version = "0.2", optional = true }
 
 [dev-dependencies]

--- a/device/src/u3v/device_builder.rs
+++ b/device/src/u3v/device_builder.rs
@@ -61,7 +61,7 @@ impl DeviceBuilder {
 
     fn build(self) -> Result<Device> {
         // TODO: Log it when device is broken or invalid.
-        let mut dev_channel = self.device.open()?;
+        let dev_channel = self.device.open()?;
         if dev_channel.active_configuration()? != self.config_desc.number() {
             dev_channel.set_active_configuration(self.config_desc.number())?;
         }


### PR DESCRIPTION
- on top of https://github.com/cameleon-rs/cameleon/pull/188 which should be merged first

...which fixes a panic in dev builds / undefined behavior in release builds: https://github.com/a1ien/rusb/pull/195

See https://github.com/cameleon-rs/cameleon/pull/188#issuecomment-2296597805 and above.

- [x] Check `test_all.sh` is passed.
- [x] Add `fix #{ISSUE_NUMBER}` if the corresponding issue exists.
- [x] Fill out `## Changelog` section. If the change is for only internal use, please write `None` to the section.

## Changelog
- Prevent a panic/undefined behavior in rusb (https://github.com/a1ien/rusb/pull/195) by allowing its newest 0.9.4 version by bumping libusb1-sys