### PR TITLE
Fixing the dst type, which is expected to be *mut i8

### DIFF
--- a/gentl/src/ffi/mod.rs
+++ b/gentl/src/ffi/mod.rs
@@ -242,7 +242,7 @@ impl CopyTo for &str {
                 if *dst_size < string_len {
                     return Err(GenTlError::BufferTooSmall);
                 }
-                std::ptr::copy_nonoverlapping(self.as_ptr().cast::<i8>(), dst, self.len());
+                std::ptr::copy_nonoverlapping(self.as_ptr().cast::<i8>(), dst.cast::<i8>(), self.len());
                 dst.add(self.len()).write(0); // Null terminated.
             }
         }


### PR DESCRIPTION
Hi, thanks for your hard work on cameleon, this is a great project!

This trivial PR fixes an error occured during my compilation, possibly with a newer version of Rust compiler:

```
245 |                 std::ptr::copy_nonoverlapping(self.as_ptr().cast::<i8>(), dst, self.len());
    |                 -----------------------------                             ^^^ expected `*mut i8`, found `*mut u8`
    |                 |
    |                 arguments to this function are incorrect
```

## Changelog

* Using a proper type casting from `*mut u8` to `*mut i8` in `std::ptr::copy_nonoverlapping`.
