### PR TITLE
I have no idea what are those payload_final2_size1 and payload_final2…

### DIFF
--- a/cameleon/src/u3v/stream_handle.rs
+++ b/cameleon/src/u3v/stream_handle.rs
@@ -552,9 +552,6 @@ fn read_payload(
         async_pool.submit(&mut buf[cursor..cursor + params.payload_final1_size])?;
         cursor += params.payload_final1_size;
     }
-    if params.payload_final2_size != 0 {
-        async_pool.submit(&mut buf[cursor..cursor + params.payload_final2_size])?;
-    }
 
     Ok(())
 }


### PR DESCRIPTION
fix #196 

I have no idea what are those `payload_final2_size1` and `payload_final2_size2 are`. But it seems that if we set the payload size to a larger value than the image frame size, the trailer packet is also appended to the payload transfer. The trailer is expected to be a separate transfer though. We set the maximum transfer size to the frame size (which is effectively equal to the value of `payload_final2_size1`) - this guarantees that the trailer will be always received in another separate bulk transfer.

This problem could be specific to `MV-A5031MU815` camera.

## Changelog

* Restrict payload bulk transfer size to be exactly equal to the image frame size, otherwise the trailer buffer is appended to the end of payload buffer