### PR TITLE
Bump version to `0.1.14`

### DIFF
--- a/cameleon/Cargo.toml
+++ b/cameleon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cameleon"
-version = "0.1.13"
+version = "0.1.14"
 authors = ["Cameleon Project Developers"]
 edition = "2018"
 license = "MPL-2.0"
@@ -23,8 +23,8 @@ sha-1 = "0.10.0"
 async-channel = "1.7.0" # 1.7.0 has added recv_blocking()
 tracing = "0.1.26"
 auto_impl = "1.0.1"
-cameleon-device = { path = "../device", version = "0.1.13" }
-cameleon-genapi = { path = "../genapi", version = "0.1.13" }
+cameleon-device = { path = "../device", version = "0.1.14" }
+cameleon-genapi = { path = "../genapi", version = "0.1.14" }
 anyhow = "1.0.40"
 
 [dev-dependencies]

--- a/device/Cargo.toml
+++ b/device/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cameleon-device"
-version = "0.1.13"
+version = "0.1.14"
 edition = "2018"
 authors = ["Cameleon Project Developers"]
 license = "MPL-2.0"
@@ -18,7 +18,7 @@ thiserror = "1.0.24"
 log = "0.4.14"
 semver = "1.0.0"
 cfg-if = "1.0.0"
-cameleon-impl = { path = "../impl", version = "0.1.13" }
+cameleon-impl = { path = "../impl", version = "0.1.14" }
 
 rusb = { version = "0.9.0", optional = true }
 libusb1-sys = { version = "0.7.0", optional = true }

--- a/genapi/Cargo.toml
+++ b/genapi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cameleon-genapi"
-version = "0.1.13"
+version = "0.1.14"
 edition = "2018"
 authors = ["Cameleon Project Developers"]
 license = "MPL-2.0"

--- a/gentl/Cargo.toml
+++ b/gentl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cameleon-gentl"
-version = "0.1.13"
+version = "0.1.14"
 authors = ["Cameleon Project Developers"]
 edition = "2018"
 license = "MPL-2.0"

--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cameleon-impl"
-version = "0.1.13"
+version = "0.1.14"
 edition = "2018"
 authors = ["Cameleon Project Developers"]
 license = "MPL-2.0"
@@ -13,7 +13,7 @@ keywords = ["genicam", "camera"]
 
 
 [dependencies]
-cameleon-impl-macros = { path = "macros", version = "0.1.13" }
+cameleon-impl-macros = { path = "macros", version = "0.1.14" }
 thiserror = "1.0.24"
 semver = "1.0.0"
 

--- a/impl/macros/Cargo.toml
+++ b/impl/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cameleon-impl-macros"
-version = "0.1.13"
+version = "0.1.14"
 authors = ["Cameleon Project Developers"]
 edition = "2018"
 license = "MPL-2.0"


### PR DESCRIPTION
This PR bumps up the version to `0.1.14` from `0.1.13`.