### PR TITLE
feat: add ttl support to CacheStore

### DIFF
--- a/cameleon/examples/custom_ctxt.rs
+++ b/cameleon/examples/custom_ctxt.rs
@@ -7,8 +7,8 @@
 //! In this example, we'll define a context in which the cache can be dynamically switched on and off.
 
 use cameleon::genapi::{
-    CacheStore, DefaultCacheStore, DefaultGenApiCtxt, DefaultNodeStore, DefaultValueStore,
-    GenApiCtxt, NodeId, ValueCtxt,
+    CacheState, CacheStore, DefaultCacheStore, DefaultGenApiCtxt, DefaultNodeStore,
+    DefaultValueStore, GenApiCtxt, NodeId, ValueCtxt,
 };
 use cameleon::{u3v, Camera};
 
@@ -18,16 +18,23 @@ struct MyCacheStore {
     use_cache: bool,
 }
 impl CacheStore for MyCacheStore {
-    fn cache(&mut self, nid: NodeId, address: i64, length: i64, data: &[u8]) {
+    fn cache(
+        &mut self,
+        nid: NodeId,
+        address: i64,
+        length: i64,
+        data: &[u8],
+        ttl: Option<std::time::Duration>,
+    ) {
         if self.use_cache {
-            self.store.cache(nid, address, length, data)
+            self.store.cache(nid, address, length, data, ttl)
         }
     }
-    fn get_cache(&self, nid: NodeId, address: i64, length: i64) -> Option<&[u8]> {
+    fn get_cache(&self, nid: NodeId, address: i64, length: i64) -> CacheState<'_> {
         if self.use_cache {
             self.store.get_cache(nid, address, length)
         } else {
-            None
+            CacheState::Miss
         }
     }
     fn invalidate_by(&mut self, nid: NodeId) {

--- a/cameleon/src/genapi/mod.rs
+++ b/cameleon/src/genapi/mod.rs
@@ -58,8 +58,8 @@ use super::{ControlError, ControlResult, DeviceControl};
 pub use cameleon_genapi::{
     elem_type::{AccessMode, NameSpace, Visibility},
     store::{
-        CacheSink, CacheStore, DefaultCacheStore, DefaultNodeStore, DefaultValueStore, NodeId,
-        NodeStore, ValueStore,
+        CacheSink, CacheState, CacheStore, DefaultCacheStore, DefaultNodeStore, DefaultValueStore,
+        NodeId, NodeStore, ValueStore,
     },
     GenApiError, RegisterDescription, ValueCtxt,
 };

--- a/genapi/src/float_reg.rs
+++ b/genapi/src/float_reg.rs
@@ -94,8 +94,6 @@ impl IFloat for FloatRegNode {
         cx: &mut ValueCtxt<T, U>,
     ) -> GenApiResult<()> {
         let nid = self.node_base().id();
-        cx.invalidate_cache_by(nid);
-
         let reg = self.register_base();
         let len = reg.length(device, store, cx)?;
         let mut buf = vec![0; len as usize];

--- a/genapi/src/int_reg.rs
+++ b/genapi/src/int_reg.rs
@@ -94,8 +94,6 @@ impl IInteger for IntRegNode {
         cx: &mut ValueCtxt<T, U>,
     ) -> GenApiResult<()> {
         let nid = self.node_base().id();
-        cx.invalidate_cache_by(nid);
-
         let reg = self.register_base();
         let len = reg.length(device, store, cx)?;
         let mut buf = vec![0; len as usize];

--- a/genapi/src/lib.rs
+++ b/genapi/src/lib.rs
@@ -61,12 +61,12 @@ pub use port::PortNode;
 pub use register::RegisterNode;
 pub use register_base::RegisterBase;
 pub use register_description::RegisterDescription;
-pub use store::{CacheStore, NodeId, NodeStore, ValueStore};
+pub use store::{CacheState, CacheStore, NodeId, NodeStore, ValueStore};
 pub use string::StringNode;
 pub use string_reg::StringRegNode;
 pub use swiss_knife::SwissKnifeNode;
 
-use std::borrow::Cow;
+use std::{borrow::Cow, time::Duration};
 
 use auto_impl::auto_impl;
 use tracing::error;
@@ -195,14 +195,20 @@ impl<T, U> ValueCtxt<T, U> {
         &mut self.cache_store
     }
 
-    pub fn cache_data(&mut self, nid: store::NodeId, address: i64, length: i64, value: &[u8])
-    where
+    pub fn cache_data(
+        &mut self,
+        nid: store::NodeId,
+        address: i64,
+        length: i64,
+        value: &[u8],
+        ttl: Option<Duration>,
+    ) where
         U: store::CacheStore,
     {
-        self.cache_store.cache(nid, address, length, value);
+        self.cache_store.cache(nid, address, length, value, ttl);
     }
 
-    pub fn get_cache(&self, nid: store::NodeId, address: i64, length: i64) -> Option<&[u8]>
+    pub fn get_cache(&self, nid: store::NodeId, address: i64, length: i64) -> store::CacheState<'_>
     where
         U: store::CacheStore,
     {

--- a/genapi/src/masked_int_reg.rs
+++ b/genapi/src/masked_int_reg.rs
@@ -110,8 +110,6 @@ impl IInteger for MaskedIntRegNode {
         cx: &mut ValueCtxt<T, U>,
     ) -> GenApiResult<()> {
         let nid = self.node_base().id();
-        cx.invalidate_cache_by(nid);
-
         let reg = self.register_base();
         let old_reg_value = reg.with_cache_or_read(nid, device, store, cx, |data| {
             utils::int_from_slice(data, self.endianness, self.sign)

--- a/genapi/src/register_base.rs
+++ b/genapi/src/register_base.rs
@@ -7,7 +7,7 @@ use super::{
     interface::IPort,
     ivalue::IValue,
     node_base::NodeElementBase,
-    store::{CacheStore, NodeId, NodeStore, ValueStore},
+    store::{CacheState, CacheStore, NodeId, NodeStore, ValueStore},
     Device, GenApiError, GenApiResult, ValueCtxt,
 };
 
@@ -66,6 +66,10 @@ impl RegisterBase {
         &self.p_invalidators
     }
 
+    fn cache_ttl(&self) -> Option<std::time::Duration> {
+        self.polling_time.map(std::time::Duration::from_millis)
+    }
+
     pub(super) fn with_cache_or_read<T: ValueStore, U: CacheStore, R>(
         &self,
         nid: NodeId,
@@ -76,12 +80,14 @@ impl RegisterBase {
     ) -> GenApiResult<R> {
         let length = self.length(device, store, cx)?;
         let address = self.address(device, store, cx)?;
-        if let Some(cache) = cx.get_cache(nid, address, length) {
-            f(cache)
-        } else {
-            let mut buf = vec![0; length as usize];
-            self.read_and_cache(nid, address, length, &mut buf, device, store, cx)?;
-            f(&buf)
+
+        match cx.get_cache(nid, address, length) {
+            CacheState::Fresh(cache) => f(cache),
+            CacheState::Miss | CacheState::Stale(_) => {
+                let mut buf = vec![0; length as usize];
+                self.read_and_cache(nid, address, length, &mut buf, device, store, cx)?;
+                f(&buf)
+            }
         }
     }
 
@@ -105,7 +111,7 @@ impl RegisterBase {
             .expect_iport_kind(store)?
             .read(address, buf, device, store, cx)?;
         if self.cacheable != CachingMode::NoCache {
-            cx.cache_data(nid, address, length, buf);
+            cx.cache_data(nid, address, length, buf, self.cache_ttl());
         }
 
         Ok(())
@@ -132,8 +138,10 @@ impl RegisterBase {
             .expect_iport_kind(store)?
             .write(address, buf, device, store, cx)?;
 
+        cx.invalidate_cache_of(nid);
+        cx.invalidate_cache_by(nid);
         if self.cacheable == CachingMode::WriteThrough {
-            cx.cache_data(nid, address, length, buf);
+            cx.cache_data(nid, address, length, buf, self.cache_ttl());
         }
         Ok(())
     }

--- a/genapi/src/store.rs
+++ b/genapi/src/store.rs
@@ -2,7 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::{collections::HashMap, convert::TryFrom};
+use std::{
+    collections::HashMap,
+    convert::TryFrom,
+    time::{Duration, Instant},
+};
 
 use auto_impl::auto_impl;
 use string_interner::{backend::StringBackend, StringInterner, Symbol};
@@ -123,15 +127,22 @@ pub trait ValueStore {
 
 #[auto_impl(&mut, Box)]
 pub trait CacheStore {
-    fn cache(&mut self, nid: NodeId, address: i64, length: i64, data: &[u8]);
+    fn cache(&mut self, nid: NodeId, address: i64, length: i64, data: &[u8], ttl: Option<Duration>);
 
-    fn get_cache(&self, nid: NodeId, address: i64, length: i64) -> Option<&[u8]>;
+    fn get_cache(&self, nid: NodeId, address: i64, length: i64) -> CacheState<'_>;
 
     fn invalidate_by(&mut self, nid: NodeId);
 
     fn invalidate_of(&mut self, nid: NodeId);
 
     fn clear(&mut self);
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CacheState<'a> {
+    Miss,
+    Fresh(&'a [u8]),
+    Stale(&'a [u8]),
 }
 
 impl Symbol for NodeId {
@@ -498,7 +509,7 @@ impl ValueStore for DefaultValueStore {
 
 #[derive(Debug, Default)]
 pub struct DefaultCacheStore {
-    store: HashMap<NodeId, HashMap<(i64, i64), Vec<u8>>>,
+    store: HashMap<NodeId, HashMap<(i64, i64), CacheEntry>>,
     invalidators: HashMap<NodeId, Vec<NodeId>>,
 }
 
@@ -507,6 +518,13 @@ impl DefaultCacheStore {
     pub fn new() -> Self {
         Self::default()
     }
+}
+
+#[derive(Debug)]
+struct CacheEntry {
+    data: Vec<u8>,
+    cached_at: Instant,
+    ttl: Option<Duration>,
 }
 
 impl builder::CacheStoreBuilder for DefaultCacheStore {
@@ -523,24 +541,61 @@ impl builder::CacheStoreBuilder for DefaultCacheStore {
 }
 
 impl CacheStore for DefaultCacheStore {
-    fn cache(&mut self, nid: NodeId, address: i64, length: i64, data: &[u8]) {
+    fn cache(
+        &mut self,
+        nid: NodeId,
+        address: i64,
+        length: i64,
+        data: &[u8],
+        ttl: Option<Duration>,
+    ) {
         self.store
             .entry(nid)
             .and_modify(|level1| {
                 level1
                     .entry((address, length))
-                    .and_modify(|level2| data.clone_into(level2))
-                    .or_insert_with(|| data.to_owned());
+                    .and_modify(|level2| {
+                        data.clone_into(&mut level2.data);
+                        level2.cached_at = Instant::now();
+                        level2.ttl = ttl;
+                    })
+                    .or_insert_with(|| CacheEntry {
+                        data: data.to_owned(),
+                        cached_at: Instant::now(),
+                        ttl,
+                    });
             })
             .or_insert_with(|| {
                 let mut level1 = HashMap::new();
-                level1.insert((address, length), data.to_owned());
+                level1.insert(
+                    (address, length),
+                    CacheEntry {
+                        data: data.to_owned(),
+                        cached_at: Instant::now(),
+                        ttl,
+                    },
+                );
                 level1
             });
     }
 
-    fn get_cache(&self, nid: NodeId, address: i64, length: i64) -> Option<&[u8]> {
-        Some(self.store.get(&nid)?.get(&(address, length))?.as_ref())
+    fn get_cache(&self, nid: NodeId, address: i64, length: i64) -> CacheState<'_> {
+        let Some(entry) = self
+            .store
+            .get(&nid)
+            .and_then(|entries| entries.get(&(address, length)))
+        else {
+            return CacheState::Miss;
+        };
+
+        if entry
+            .ttl
+            .is_some_and(|ttl| entry.cached_at.elapsed() >= ttl)
+        {
+            CacheState::Stale(entry.data.as_ref())
+        } else {
+            CacheState::Fresh(entry.data.as_ref())
+        }
     }
 
     fn invalidate_by(&mut self, nid: NodeId) {
@@ -588,10 +643,10 @@ impl builder::CacheStoreBuilder for CacheSink {
 }
 
 impl CacheStore for CacheSink {
-    fn cache(&mut self, _: NodeId, _: i64, _: i64, _: &[u8]) {}
+    fn cache(&mut self, _: NodeId, _: i64, _: i64, _: &[u8], _: Option<Duration>) {}
 
-    fn get_cache(&self, _: NodeId, _: i64, _: i64) -> Option<&[u8]> {
-        None
+    fn get_cache(&self, _: NodeId, _: i64, _: i64) -> CacheState<'_> {
+        CacheState::Miss
     }
 
     fn invalidate_by(&mut self, _: NodeId) {}

--- a/genapi/src/string_reg.rs
+++ b/genapi/src/string_reg.rs
@@ -77,8 +77,6 @@ impl IString for StringRegNode {
         }
 
         let nid = self.node_base().id();
-        cx.invalidate_cache_by(nid);
-
         let reg = self.register_base();
         let mut bytes = value.into_bytes();
         bytes.resize(max_length, 0);


### PR DESCRIPTION
<!--
Thank you for improving `Cameleon`!

Please fill out the checklist before opening the PR.
-->

- [x] Check `test_all.sh` is passed.
- [x] Add `fix #{ISSUE_NUMBER}` if the corresponding issue exists.
- [x] Fill out `## Changelog` section. If the change is for only internal use, please write `None` to the section.

<!--
We collect a changelog from a PR description, so please write a brief description about the change in the following `Changelog` section.
-->
## Changelog

* Added TTL support to CacheStore and introduced CacheState to distinguish fresh, stale, and missing entries.
* Updated register cache handling so stale entries are re-read automatically and PollingTime is used as cache TTL when available.
