### PR TITLE
Support for rounding precision in formula

### DIFF
--- a/genapi/src/formula.rs
+++ b/genapi/src/formula.rs
@@ -183,6 +183,11 @@ impl Expr {
             }
             BinOpKind::Or => (self.eval(var_env)?.as_bool() || rhs.eval(var_env)?.as_bool()).into(),
 
+            BinOpKind::Round => {
+                let factor = 10_f64.powi(rhs.eval(var_env)?.as_integer() as i32);
+                ((self.eval(var_env)?.as_float() * factor).round() / factor).into()
+            }
+
             _ => {
                 let lhs = self.eval(var_env)?;
                 let rhs = rhs.eval(var_env)?;
@@ -290,10 +295,6 @@ impl Expr {
             UnOpKind::Trunc => res.as_float().trunc().into(),
             UnOpKind::Floor => res.as_float().floor().into(),
             UnOpKind::Ceil => res.as_float().ceil().into(),
-            UnOpKind::Round(precision) => {
-                let factor = 10_f64.powi(precision);
-                ((res.as_float() * factor).round() / factor).into()
-            }
         })
     }
 }
@@ -319,6 +320,7 @@ pub enum BinOpKind {
     BitAnd,
     BitOr,
     Xor,
+    Round,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -340,7 +342,6 @@ pub enum UnOpKind {
     Trunc,
     Floor,
     Ceil,
-    Round(i32),
 }
 
 #[must_use]
@@ -523,15 +524,16 @@ impl Parser<'_> {
                     "ROUND" => {
                         let expr = self.expr();
                         let precision = if self.eat(&Token::Comma) {
-                            self.next_integer().unwrap()
+                            self.expr()
                         } else {
-                            0
+                            Expr::Integer(0)
                         };
 
                         self.expect(&Token::RParen);
-                        return Expr::UnOp {
-                            kind: UnOpKind::Round(precision as i32),
-                            expr: expr.into(),
+                        return Expr::BinOp {
+                            kind: BinOpKind::Round,
+                            lhs: expr.into(),
+                            rhs: precision.into(),
                         };
                     }
                     other => panic!("{} is not a keyword or function name", other),
@@ -904,6 +906,7 @@ mod tests {
         test_eval_no_var_impl("(0xff00 ^ 0xf0f0) = 0x0ff0");
         test_eval_no_var_impl("(~0) = (0 - 1)");
         test_eval_no_var_impl("ROUND ((1 / 10) + 0.049, 3) = 0.149");
+        test_eval_no_var_impl("ROUND ((1 / 10) + 0.049, 1 + 2) = 0.149");
         test_eval_no_var_impl("ROUND ((1 / 10) + 0.049, 2) = 0.15");
         test_eval_no_var_impl("ROUND ((1 / 10) + 0.049, 1) = 0.1");
         test_eval_no_var_impl("ROUND ((1 / 10) + 0.049, 0) = 0");

--- a/genapi/src/formula.rs
+++ b/genapi/src/formula.rs
@@ -177,82 +177,80 @@ impl Expr {
     {
         use std::ops::{Add, Mul, Rem, Sub};
 
+        let lhs = self.eval(var_env)?;
+        let rhs = rhs.eval(var_env)?;
+
+        macro_rules! apply_arithmetic_op {
+            ($fint:ident, $ffloat:ident) => {{
+                if lhs.is_integer() && rhs.is_integer() {
+                    (lhs.as_integer().$fint(rhs.as_integer())).0.into()
+                } else {
+                    (lhs.as_float().$ffloat(rhs.as_float())).into()
+                }
+            }};
+        }
+
+        macro_rules! apply_cmp_op {
+            ($fint:ident, $ffloat:ident) => {{
+                if lhs.is_integer() && rhs.is_integer() {
+                    (lhs.as_integer().$fint(&rhs.as_integer())).into()
+                } else {
+                    (lhs.as_float().$ffloat(&rhs.as_float())).into()
+                }
+            }};
+        }
+
         Ok(match op {
-            BinOpKind::And => {
-                (self.eval(var_env)?.as_bool() && rhs.eval(var_env)?.as_bool()).into()
-            }
-            BinOpKind::Or => (self.eval(var_env)?.as_bool() || rhs.eval(var_env)?.as_bool()).into(),
+            BinOpKind::And => (lhs.as_bool() && rhs.as_bool()).into(),
+            BinOpKind::Or => (lhs.as_bool() || rhs.as_bool()).into(),
 
             BinOpKind::Round => {
-                let factor = 10_f64.powi(rhs.eval(var_env)?.as_integer() as i32);
-                ((self.eval(var_env)?.as_float() * factor).round() / factor).into()
+                let factor = match rhs {
+                    EvaluationResult::Integer(0) => return Ok(lhs.as_float().round().into()),
+                    EvaluationResult::Integer(n) => 10_f64.powi(n as i32),
+                    EvaluationResult::Float(f) => 10_f64.powf(f),
+                };
+                ((lhs.as_float() * factor).round() / factor).into()
             }
 
-            _ => {
-                let lhs = self.eval(var_env)?;
-                let rhs = rhs.eval(var_env)?;
-
-                macro_rules! apply_arithmetic_op {
-                    ($fint:ident, $ffloat:ident) => {{
-                        if lhs.is_integer() && rhs.is_integer() {
-                            (lhs.as_integer().$fint(rhs.as_integer())).0.into()
-                        } else {
-                            (lhs.as_float().$ffloat(rhs.as_float())).into()
-                        }
-                    }};
-                }
-
-                macro_rules! apply_cmp_op {
-                    ($fint:ident, $ffloat:ident) => {{
-                        if lhs.is_integer() && rhs.is_integer() {
-                            (lhs.as_integer().$fint(&rhs.as_integer())).into()
-                        } else {
-                            (lhs.as_float().$ffloat(&rhs.as_float())).into()
-                        }
-                    }};
-                }
-                match op {
-                    BinOpKind::Add => apply_arithmetic_op!(overflowing_add, add),
-                    BinOpKind::Sub => apply_arithmetic_op!(overflowing_sub, sub),
-                    BinOpKind::Mul => apply_arithmetic_op!(overflowing_mul, mul),
-                    BinOpKind::Div => {
-                        // Division must be treated as floating points.
-                        // e.g. Converter node with `<FormulaFrom>TO/(1&lt;&lt;P1)</FormulaFrom>` where `P1` points to integer node are commonplace.
-                        (lhs.as_float() / rhs.as_float()).into()
-                    }
-                    BinOpKind::Rem => apply_arithmetic_op!(overflowing_rem, rem),
-                    BinOpKind::Pow => {
-                        if lhs.is_integer() && rhs.is_integer() && rhs.as_integer() >= 0 {
-                            lhs.as_integer()
-                                .overflowing_pow(rhs.as_integer() as u32)
-                                .0
-                                .into()
-                        } else {
-                            lhs.as_float().powf(rhs.as_float()).into()
-                        }
-                    }
-                    BinOpKind::Eq => apply_cmp_op!(eq, eq),
-                    BinOpKind::Ne => apply_cmp_op!(ne, ne),
-                    BinOpKind::Lt => apply_cmp_op!(lt, lt),
-                    BinOpKind::Le => apply_cmp_op!(le, le),
-                    BinOpKind::Gt => apply_cmp_op!(gt, gt),
-                    BinOpKind::Ge => apply_cmp_op!(ge, ge),
-                    BinOpKind::Shl => lhs
-                        .as_integer()
-                        .overflowing_shl(rhs.as_integer() as u32)
+            BinOpKind::Add => apply_arithmetic_op!(overflowing_add, add),
+            BinOpKind::Sub => apply_arithmetic_op!(overflowing_sub, sub),
+            BinOpKind::Mul => apply_arithmetic_op!(overflowing_mul, mul),
+            BinOpKind::Div => {
+                // Division must be treated as floating points.
+                // e.g. Converter node with `<FormulaFrom>TO/(1&lt;&lt;P1)</FormulaFrom>` where `P1` points to integer node are commonplace.
+                (lhs.as_float() / rhs.as_float()).into()
+            }
+            BinOpKind::Rem => apply_arithmetic_op!(overflowing_rem, rem),
+            BinOpKind::Pow => {
+                if lhs.is_integer() && rhs.is_integer() && rhs.as_integer() >= 0 {
+                    lhs.as_integer()
+                        .overflowing_pow(rhs.as_integer() as u32)
                         .0
-                        .into(),
-                    BinOpKind::Shr => lhs
-                        .as_integer()
-                        .overflowing_shr(rhs.as_integer() as u32)
-                        .0
-                        .into(),
-                    BinOpKind::BitAnd => (lhs.as_integer() & rhs.as_integer()).into(),
-                    BinOpKind::BitOr => (lhs.as_integer() | rhs.as_integer()).into(),
-                    BinOpKind::Xor => (lhs.as_integer() ^ rhs.as_integer()).into(),
-                    _ => unreachable!(),
+                        .into()
+                } else {
+                    lhs.as_float().powf(rhs.as_float()).into()
                 }
             }
+            BinOpKind::Eq => apply_cmp_op!(eq, eq),
+            BinOpKind::Ne => apply_cmp_op!(ne, ne),
+            BinOpKind::Lt => apply_cmp_op!(lt, lt),
+            BinOpKind::Le => apply_cmp_op!(le, le),
+            BinOpKind::Gt => apply_cmp_op!(gt, gt),
+            BinOpKind::Ge => apply_cmp_op!(ge, ge),
+            BinOpKind::Shl => lhs
+                .as_integer()
+                .overflowing_shl(rhs.as_integer() as u32)
+                .0
+                .into(),
+            BinOpKind::Shr => lhs
+                .as_integer()
+                .overflowing_shr(rhs.as_integer() as u32)
+                .0
+                .into(),
+            BinOpKind::BitAnd => (lhs.as_integer() & rhs.as_integer()).into(),
+            BinOpKind::BitOr => (lhs.as_integer() | rhs.as_integer()).into(),
+            BinOpKind::Xor => (lhs.as_integer() ^ rhs.as_integer()).into(),
         })
     }
 

--- a/genapi/src/formula.rs
+++ b/genapi/src/formula.rs
@@ -290,7 +290,10 @@ impl Expr {
             UnOpKind::Trunc => res.as_float().trunc().into(),
             UnOpKind::Floor => res.as_float().floor().into(),
             UnOpKind::Ceil => res.as_float().ceil().into(),
-            UnOpKind::Round => res.as_float().round().into(),
+            UnOpKind::Round(precision) => {
+                let factor = 10_f64.powi(precision);
+                ((res.as_float() * factor).round() / factor).into()
+            }
         })
     }
 }
@@ -337,7 +340,7 @@ pub enum UnOpKind {
     Trunc,
     Floor,
     Ceil,
-    Round,
+    Round(i32),
 }
 
 #[must_use]
@@ -517,7 +520,20 @@ impl Parser<'_> {
                     "TRUNC" => UnOpKind::Trunc,
                     "FLOOR" => UnOpKind::Floor,
                     "CEIL" => UnOpKind::Ceil,
-                    "ROUND" => UnOpKind::Round,
+                    "ROUND" => {
+                        let expr = self.expr();
+                        let precision = if self.eat(&Token::Comma) {
+                            self.next_integer().unwrap()
+                        } else {
+                            0
+                        };
+
+                        self.expect(&Token::RParen);
+                        return Expr::UnOp {
+                            kind: UnOpKind::Round(precision as i32),
+                            expr: expr.into(),
+                        };
+                    }
                     other => panic!("{} is not a keyword or function name", other),
                 };
                 let expr = self.expr();
@@ -585,6 +601,7 @@ impl Parser<'_> {
 
 #[derive(Debug, Clone, PartialEq)]
 enum Token {
+    Comma,
     LParen,
     RParen,
     Plus,
@@ -645,6 +662,7 @@ impl<'a> Lexer<'a> {
         while self.eat_char(|c| c.is_whitespace() || c.is_ascii_control()) {}
 
         self.peek = Some(match self.next_char()? {
+            ',' => Token::Comma,
             '(' => Token::LParen,
             ')' => Token::RParen,
             '+' => Token::Plus,
@@ -818,6 +836,9 @@ mod tests {
 
     #[test]
     fn test_lexer() {
+        let t = Lexer::new(",123").next().unwrap();
+        assert_eq!(Token::Comma, t);
+
         let t = Lexer::new("&amp;").next().unwrap();
         assert_eq!(Token::And, t);
 
@@ -882,6 +903,11 @@ mod tests {
         test_eval_no_var_impl("(0xff00 | 0xf0f0) = 0xfff0");
         test_eval_no_var_impl("(0xff00 ^ 0xf0f0) = 0x0ff0");
         test_eval_no_var_impl("(~0) = (0 - 1)");
+        test_eval_no_var_impl("ROUND ((1 / 10) + 0.049, 3) = 0.149");
+        test_eval_no_var_impl("ROUND ((1 / 10) + 0.049, 2) = 0.15");
+        test_eval_no_var_impl("ROUND ((1 / 10) + 0.049, 1) = 0.1");
+        test_eval_no_var_impl("ROUND ((1 / 10) + 0.049, 0) = 0");
+        test_eval_no_var_impl("ROUND ((1 / 10) + 0.049) = 0");
     }
 
     #[test]


### PR DESCRIPTION
The GenICam Standard v2.1.1 support an optional precision argument for the ROUND function.
E.g: `ROUND (((TO / 10.24) + 0.049), 1)` -> round expression to the first decimal place.

## Changelog
- Added parsing support for the optional given precision of the ROUND function