### PR TITLE
feat(genapi): resolve converter bounds and increments

### DIFF
--- a/genapi/src/converter.rs
+++ b/genapi/src/converter.rs
@@ -4,12 +4,20 @@
 
 use super::{
     elem_type::{DisplayNotation, FloatRepresentation, NamedValue, Slope},
-    formula::{Expr, Formula},
+    formula::{EvaluationResult, Expr, Formula},
     interface::{IFloat, INode, IncrementMode},
     node_base::{NodeAttributeBase, NodeBase, NodeElementBase},
     store::{CacheStore, NodeId, NodeStore, ValueStore},
     utils, Device, GenApiError, GenApiResult, ValueCtxt,
 };
+
+fn expr_as_float(expr: Expr) -> f64 {
+    match expr {
+        Expr::Integer(i) => i as f64,
+        Expr::Float(f) => f,
+        _ => unreachable!("node min/max/inc values must evaluate to immediate expressions"),
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct ConverterNode {
@@ -91,6 +99,21 @@ impl ConverterNode {
     pub fn is_linear(&self) -> bool {
         self.is_linear
     }
+
+    fn eval_formula_from<T: ValueStore, U: CacheStore>(
+        &self,
+        to: impl Into<Expr>,
+        device: &mut impl Device,
+        store: &impl NodeStore,
+        cx: &mut ValueCtxt<T, U>,
+    ) -> GenApiResult<EvaluationResult> {
+        let mut collector =
+            utils::FormulaEnvCollector::new(&self.p_variables, &self.constants, &self.expressions);
+        collector.insert_imm("TO", to);
+        let var_env = collector.collect(device, store, cx)?;
+
+        self.formula_from.eval(&var_env)
+    }
 }
 
 impl INode for ConverterNode {
@@ -146,20 +169,24 @@ impl IFloat for ConverterNode {
 
     fn min<T: ValueStore, U: CacheStore>(
         &self,
-        _: &mut impl Device,
-        _: &impl NodeStore,
-        _: &mut ValueCtxt<T, U>,
+        device: &mut impl Device,
+        store: &impl NodeStore,
+        cx: &mut ValueCtxt<T, U>,
     ) -> GenApiResult<f64> {
-        Ok(f64::MIN)
+        let raw_min = utils::min_from_nid(self.p_value, device, store, cx)?;
+        self.eval_formula_from(raw_min, device, store, cx)
+            .map(|value| value.as_float())
     }
 
     fn max<T: ValueStore, U: CacheStore>(
         &self,
-        _: &mut impl Device,
-        _: &impl NodeStore,
-        _: &mut ValueCtxt<T, U>,
+        device: &mut impl Device,
+        store: &impl NodeStore,
+        cx: &mut ValueCtxt<T, U>,
     ) -> GenApiResult<f64> {
-        Ok(f64::MAX)
+        let raw_max = utils::max_from_nid(self.p_value, device, store, cx)?;
+        self.eval_formula_from(raw_max, device, store, cx)
+            .map(|value| value.as_float())
     }
 
     fn inc_mode(&self, _: &impl NodeStore) -> Option<IncrementMode> {
@@ -168,11 +195,23 @@ impl IFloat for ConverterNode {
 
     fn inc<T: ValueStore, U: CacheStore>(
         &self,
-        _: &mut impl Device,
-        _: &impl NodeStore,
-        _: &mut ValueCtxt<T, U>,
+        device: &mut impl Device,
+        store: &impl NodeStore,
+        cx: &mut ValueCtxt<T, U>,
     ) -> GenApiResult<Option<f64>> {
-        Ok(None)
+        let Some(raw_inc) = utils::inc_from_nid(self.p_value, device, store, cx)? else {
+            return Ok(None);
+        };
+        let raw_min = expr_as_float(utils::min_from_nid(self.p_value, device, store, cx)?);
+        let raw_inc = expr_as_float(raw_inc);
+        let min_plus_inc = self
+            .eval_formula_from(raw_min + raw_inc, device, store, cx)?
+            .as_float();
+        let min = self
+            .eval_formula_from(raw_min, device, store, cx)?
+            .as_float();
+
+        Ok(Some(min_plus_inc - min))
     }
 
     fn representation(&self, _: &impl NodeStore) -> FloatRepresentation {
@@ -247,5 +286,166 @@ impl IFloat for ConverterNode {
         Ok(self.elem_base.is_writable(device, store, cx)?
             && utils::is_nid_writable(self.p_value, device, store, cx)?
             && collector.is_readable(device, store, cx)?) // Collector is needed to be readable to write a value.
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        builder::GenApiBuilder,
+        prelude::{IFloat, IInteger},
+        store::{DefaultCacheStore, DefaultNodeStore, DefaultValueStore, NodeStore},
+        Device, RegisterDescription, ValueCtxt,
+    };
+
+    struct DummyDevice;
+
+    impl Device for DummyDevice {
+        fn read_mem(
+            &mut self,
+            _: i64,
+            _: &mut [u8],
+        ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+            unreachable!()
+        }
+
+        fn write_mem(
+            &mut self,
+            _: i64,
+            _: &[u8],
+        ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+            unreachable!()
+        }
+    }
+
+    #[test]
+    fn test_converter_min_max_inc_from_p_value() {
+        let xml = r#"
+        <RegisterDescription
+          ModelName="CameleonModel"
+          VendorName="CameleonVendor"
+          StandardNameSpace="None"
+          SchemaMajorVersion="1"
+          SchemaMinorVersion="1"
+          SchemaSubMinorVersion="0"
+          MajorVersion="1"
+          MinorVersion="0"
+          SubMinorVersion="0"
+          ProductGuid="01234567-0123-0123-0123-0123456789ab"
+          VersionGuid="76543210-3210-3210-3210-ba9876543210"
+          xmlns="http://www.genicam.org/GenApi/Version_1_0">
+
+            <Category Name="Root" NameSpace="Standard">
+                <pFeature>Converted</pFeature>
+            </Category>
+
+            <Integer Name="Scale">
+                <Value>3</Value>
+            </Integer>
+
+            <Integer Name="Raw">
+                <Value>10</Value>
+                <Min>10</Min>
+                <Max>20</Max>
+                <Inc>2</Inc>
+            </Integer>
+
+            <Float Name="Alias">
+                <pValue>Raw</pValue>
+            </Float>
+
+            <Converter Name="Converted">
+                <pVariable Name="Scale">Scale</pVariable>
+                <FormulaTo>(FROM - 5) / Scale</FormulaTo>
+                <FormulaFrom>TO * Scale + 5</FormulaFrom>
+                <pValue>Alias</pValue>
+             </Converter>
+        </RegisterDescription>
+        "#;
+
+        let (_, node_store, mut value_ctxt): (
+            RegisterDescription,
+            DefaultNodeStore,
+            ValueCtxt<DefaultValueStore, DefaultCacheStore>,
+        ) = GenApiBuilder::<DefaultNodeStore, DefaultValueStore, DefaultCacheStore>::default()
+            .build(&xml)
+            .unwrap();
+        let node_id = node_store.id_by_name("Converted").unwrap();
+        let node = node_id.expect_ifloat_kind(&node_store).unwrap();
+        let mut device = DummyDevice;
+
+        assert_eq!(
+            node.min(&mut device, &node_store, &mut value_ctxt).unwrap(),
+            35.0
+        );
+        assert_eq!(
+            node.max(&mut device, &node_store, &mut value_ctxt).unwrap(),
+            65.0
+        );
+        assert_eq!(
+            node.inc(&mut device, &node_store, &mut value_ctxt).unwrap(),
+            Some(6.0)
+        );
+    }
+
+    #[test]
+    fn test_int_converter_min_max_inc_from_p_value() {
+        let xml = r#"
+        <RegisterDescription
+          ModelName="CameleonModel"
+          VendorName="CameleonVendor"
+          StandardNameSpace="None"
+          SchemaMajorVersion="1"
+          SchemaMinorVersion="1"
+          SchemaSubMinorVersion="0"
+          MajorVersion="1"
+          MinorVersion="0"
+          SubMinorVersion="0"
+          ProductGuid="01234567-0123-0123-0123-0123456789ab"
+          VersionGuid="76543210-3210-3210-3210-ba9876543210"
+          xmlns="http://www.genicam.org/GenApi/Version_1_0">
+
+            <Category Name="Root" NameSpace="Standard">
+                <pFeature>Converted</pFeature>
+            </Category>
+
+            <Integer Name="Raw">
+                <Value>10</Value>
+                <Min>10</Min>
+                <Max>20</Max>
+                <Inc>2</Inc>
+            </Integer>
+
+            <IntConverter Name="Converted">
+                <FormulaTo>(FROM - 5) / 3</FormulaTo>
+                <FormulaFrom>TO * 3 + 5</FormulaFrom>
+                <pValue>Raw</pValue>
+             </IntConverter>
+        </RegisterDescription>
+        "#;
+
+        let (_, node_store, mut value_ctxt): (
+            RegisterDescription,
+            DefaultNodeStore,
+            ValueCtxt<DefaultValueStore, DefaultCacheStore>,
+        ) = GenApiBuilder::<DefaultNodeStore, DefaultValueStore, DefaultCacheStore>::default()
+            .build(&xml)
+            .unwrap();
+        let node_id = node_store.id_by_name("Converted").unwrap();
+        let node = node_id.expect_iinteger_kind(&node_store).unwrap();
+        let mut device = DummyDevice;
+
+        assert_eq!(
+            node.min(&mut device, &node_store, &mut value_ctxt).unwrap(),
+            35
+        );
+        assert_eq!(
+            node.max(&mut device, &node_store, &mut value_ctxt).unwrap(),
+            65
+        );
+        assert_eq!(
+            node.inc(&mut device, &node_store, &mut value_ctxt).unwrap(),
+            Some(6)
+        );
     }
 }

--- a/genapi/src/float.rs
+++ b/genapi/src/float.rs
@@ -4,7 +4,7 @@
 
 use super::{
     elem_type::{DisplayNotation, FloatRepresentation, ImmOrPNode, ValueKind},
-    interface::{IFloat, INode, IncrementMode},
+    interface::{IFloat, IInteger, INode, IncrementMode},
     ivalue::IValue,
     node_base::{NodeAttributeBase, NodeBase, NodeElementBase},
     store::{CacheStore, FloatId, NodeStore, ValueStore},
@@ -67,6 +67,10 @@ impl FloatNode {
     pub fn display_precision_elem(&self) -> i64 {
         self.display_precision
     }
+
+    fn p_value(&self) -> Option<super::store::NodeId> {
+        self.value_kind.p_value().map(|p_value| p_value.p_value())
+    }
 }
 
 impl INode for FloatNode {
@@ -115,7 +119,19 @@ impl IFloat for FloatNode {
         store: &impl NodeStore,
         cx: &mut ValueCtxt<T, U>,
     ) -> GenApiResult<f64> {
-        self.min.value(device, store, cx)
+        let value = self.min.value(device, store, cx)?;
+        if value == f64::MIN {
+            if let Some(p_value) = self.p_value() {
+                if let Some(node) = p_value.as_ifloat_kind(store) {
+                    return node.min(device, store, cx);
+                }
+                if let Some(node) = p_value.as_iinteger_kind(store) {
+                    return node.min(device, store, cx).map(|value| value as f64);
+                }
+            }
+        }
+
+        Ok(value)
     }
 
     #[tracing::instrument(skip(self, device, store, cx),
@@ -127,7 +143,19 @@ impl IFloat for FloatNode {
         store: &impl NodeStore,
         cx: &mut ValueCtxt<T, U>,
     ) -> GenApiResult<f64> {
-        self.max.value(device, store, cx)
+        let value = self.max.value(device, store, cx)?;
+        if value == f64::MAX {
+            if let Some(p_value) = self.p_value() {
+                if let Some(node) = p_value.as_ifloat_kind(store) {
+                    return node.max(device, store, cx);
+                }
+                if let Some(node) = p_value.as_iinteger_kind(store) {
+                    return node.max(device, store, cx).map(|value| value as f64);
+                }
+            }
+        }
+
+        Ok(value)
     }
 
     fn inc_mode(&self, _store: &impl NodeStore) -> Option<IncrementMode> {
@@ -143,7 +171,21 @@ impl IFloat for FloatNode {
         store: &impl NodeStore,
         cx: &mut ValueCtxt<T, U>,
     ) -> GenApiResult<Option<f64>> {
-        self.inc.map(|n| n.value(device, store, cx)).transpose()
+        let inc = self.inc.map(|n| n.value(device, store, cx)).transpose()?;
+        if inc.is_none() {
+            if let Some(p_value) = self.p_value() {
+                if let Some(node) = p_value.as_ifloat_kind(store) {
+                    return node.inc(device, store, cx);
+                }
+                if let Some(node) = p_value.as_iinteger_kind(store) {
+                    return node
+                        .inc(device, store, cx)
+                        .map(|inc| inc.map(|value| value as f64));
+                }
+            }
+        }
+
+        Ok(inc)
     }
 
     fn representation(&self, _store: &impl NodeStore) -> FloatRepresentation {

--- a/genapi/src/int_converter.rs
+++ b/genapi/src/int_converter.rs
@@ -4,12 +4,20 @@
 
 use super::{
     elem_type::{IntegerRepresentation, NamedValue, Slope},
-    formula::{Expr, Formula},
+    formula::{EvaluationResult, Expr, Formula},
     interface::{IInteger, INode, IncrementMode},
     node_base::{NodeAttributeBase, NodeBase, NodeElementBase},
     store::{CacheStore, NodeId, NodeStore, ValueStore},
     utils, Device, GenApiError, GenApiResult, ValueCtxt,
 };
+
+fn expr_as_integer(expr: Expr) -> i64 {
+    match expr {
+        Expr::Integer(i) => i,
+        Expr::Float(f) => f as i64,
+        _ => unreachable!("node min/max/inc values must evaluate to immediate expressions"),
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct IntConverterNode {
@@ -73,6 +81,21 @@ impl IntConverterNode {
     pub fn slope(&self) -> Slope {
         self.slope
     }
+
+    fn eval_formula_from<T: ValueStore, U: CacheStore>(
+        &self,
+        to: impl Into<Expr>,
+        device: &mut impl Device,
+        store: &impl NodeStore,
+        cx: &mut ValueCtxt<T, U>,
+    ) -> GenApiResult<EvaluationResult> {
+        let mut collector =
+            utils::FormulaEnvCollector::new(&self.p_variables, &self.constants, &self.expressions);
+        collector.insert_imm("TO", to);
+        let var_env = collector.collect(device, store, cx)?;
+
+        self.formula_from.eval(&var_env)
+    }
 }
 
 impl INode for IntConverterNode {
@@ -128,20 +151,24 @@ impl IInteger for IntConverterNode {
 
     fn min<T: ValueStore, U: CacheStore>(
         &self,
-        _: &mut impl Device,
-        _: &impl NodeStore,
-        _: &mut ValueCtxt<T, U>,
+        device: &mut impl Device,
+        store: &impl NodeStore,
+        cx: &mut ValueCtxt<T, U>,
     ) -> GenApiResult<i64> {
-        Ok(i64::MIN)
+        let raw_min = utils::min_from_nid(self.p_value, device, store, cx)?;
+        self.eval_formula_from(raw_min, device, store, cx)
+            .map(|value| value.as_integer())
     }
 
     fn max<T: ValueStore, U: CacheStore>(
         &self,
-        _: &mut impl Device,
-        _: &impl NodeStore,
-        _: &mut ValueCtxt<T, U>,
+        device: &mut impl Device,
+        store: &impl NodeStore,
+        cx: &mut ValueCtxt<T, U>,
     ) -> GenApiResult<i64> {
-        Ok(i64::MAX)
+        let raw_max = utils::max_from_nid(self.p_value, device, store, cx)?;
+        self.eval_formula_from(raw_max, device, store, cx)
+            .map(|value| value.as_integer())
     }
 
     fn inc_mode(&self, _: &impl NodeStore) -> Option<IncrementMode> {
@@ -150,11 +177,23 @@ impl IInteger for IntConverterNode {
 
     fn inc<T: ValueStore, U: CacheStore>(
         &self,
-        _: &mut impl Device,
-        _: &impl NodeStore,
-        _: &mut ValueCtxt<T, U>,
+        device: &mut impl Device,
+        store: &impl NodeStore,
+        cx: &mut ValueCtxt<T, U>,
     ) -> GenApiResult<Option<i64>> {
-        Ok(None)
+        let Some(raw_inc) = utils::inc_from_nid(self.p_value, device, store, cx)? else {
+            return Ok(None);
+        };
+        let raw_min = expr_as_integer(utils::min_from_nid(self.p_value, device, store, cx)?);
+        let raw_inc = expr_as_integer(raw_inc);
+        let min_plus_inc = self
+            .eval_formula_from(raw_min + raw_inc, device, store, cx)?
+            .as_integer();
+        let min = self
+            .eval_formula_from(raw_min, device, store, cx)?
+            .as_integer();
+
+        Ok(Some(min_plus_inc - min))
     }
 
     fn valid_value_set(&self, _: &impl NodeStore) -> &[i64] {

--- a/genapi/src/utils.rs
+++ b/genapi/src/utils.rs
@@ -6,8 +6,7 @@ use std::{borrow::Cow, collections::HashMap, convert::TryInto};
 
 use super::{
     elem_type::{Endianness, NamedValue, Sign},
-    formula::EvaluationResult,
-    formula::Expr,
+    formula::{EvaluationResult, Expr},
     interface::{IBoolean, IEnumeration, IFloat, IInteger},
     store::{CacheStore, NodeId, NodeStore, ValueStore},
     Device, GenApiError, GenApiResult, ValueCtxt,
@@ -207,6 +206,67 @@ impl<'a, T: Copy + Into<Expr>> FormulaEnvCollector<'a, T> {
     }
 }
 
+pub(super) fn min_from_nid<T, U>(
+    nid: NodeId,
+    device: &mut impl Device,
+    store: &impl NodeStore,
+    cx: &mut ValueCtxt<T, U>,
+) -> GenApiResult<Expr>
+where
+    T: ValueStore,
+    U: CacheStore,
+{
+    if let Some(node) = nid.as_iinteger_kind(store) {
+        node.min(device, store, cx).map(Into::into)
+    } else if let Some(node) = nid.as_ifloat_kind(store) {
+        node.min(device, store, cx).map(Into::into)
+    } else {
+        Err(invalid_p_variable_nid(nid, store))
+    }
+}
+
+pub(super) fn max_from_nid<T, U>(
+    nid: NodeId,
+    device: &mut impl Device,
+    store: &impl NodeStore,
+    cx: &mut ValueCtxt<T, U>,
+) -> GenApiResult<Expr>
+where
+    T: ValueStore,
+    U: CacheStore,
+{
+    if let Some(node) = nid.as_iinteger_kind(store) {
+        node.max(device, store, cx).map(Into::into)
+    } else if let Some(node) = nid.as_ifloat_kind(store) {
+        node.max(device, store, cx).map(Into::into)
+    } else {
+        Err(invalid_p_variable_nid(nid, store))
+    }
+}
+
+pub(super) fn inc_from_nid<T, U>(
+    nid: NodeId,
+    device: &mut impl Device,
+    store: &impl NodeStore,
+    cx: &mut ValueCtxt<T, U>,
+) -> GenApiResult<Option<Expr>>
+where
+    T: ValueStore,
+    U: CacheStore,
+{
+    if let Some(node) = nid.as_iinteger_kind(store) {
+        node.inc(device, store, cx).map(|inc| inc.map(Into::into))
+    } else if let Some(node) = nid.as_ifloat_kind(store) {
+        node.inc(device, store, cx).map(|inc| inc.map(Into::into))
+    } else {
+        Err(invalid_p_variable_nid(nid, store))
+    }
+}
+
+fn invalid_p_variable_nid(nid: NodeId, store: &impl NodeStore) -> GenApiError {
+    GenApiError::invalid_node(format!("invalid `pVariable: {}`", nid.name(store)).into())
+}
+
 #[derive(Debug)]
 enum VariableKind<'a> {
     Value,
@@ -240,52 +300,21 @@ impl<'a> VariableKind<'a> {
         store: &impl NodeStore,
         cx: &mut ValueCtxt<T, U>,
     ) -> GenApiResult<Expr> {
-        fn error(nid: NodeId, store: &impl NodeStore) -> GenApiError {
-            GenApiError::invalid_node(format!("invalid `pVariable: {}`", nid.name(store)).into())
-        }
-
         let expr: Expr = match self {
             Self::Value => expr_from_nid(nid, device, store, cx)?,
-            Self::Min => {
-                if let Some(node) = nid.as_iinteger_kind(store) {
-                    node.min(device, store, cx)?.into()
-                } else if let Some(node) = nid.as_ifloat_kind(store) {
-                    node.min(device, store, cx)?.into()
-                } else {
-                    return Err(error(nid, store));
-                }
-            }
-            Self::Max => {
-                if let Some(node) = nid.as_iinteger_kind(store) {
-                    node.max(device, store, cx)?.into()
-                } else if let Some(node) = nid.as_ifloat_kind(store) {
-                    node.max(device, store, cx)?.into()
-                } else {
-                    return Err(error(nid, store));
-                }
-            }
-            Self::Inc => {
-                if let Some(node) = nid.as_iinteger_kind(store) {
-                    node.inc(device, store, cx)?
-                        .ok_or_else(|| error(nid, store))?
-                        .into()
-                } else if let Some(node) = nid.as_ifloat_kind(store) {
-                    node.inc(device, store, cx)?
-                        .ok_or_else(|| error(nid, store))?
-                        .into()
-                } else {
-                    return Err(error(nid, store));
-                }
-            }
+            Self::Min => min_from_nid(nid, device, store, cx)?,
+            Self::Max => max_from_nid(nid, device, store, cx)?,
+            Self::Inc => inc_from_nid(nid, device, store, cx)?
+                .ok_or_else(|| invalid_p_variable_nid(nid, store))?,
             Self::Enum(name) => {
                 if let Some(node) = nid.as_ienumeration_kind(store) {
                     node.entry_by_symbolic(name, store)
-                        .ok_or_else(|| error(nid, store))
+                        .ok_or_else(|| invalid_p_variable_nid(nid, store))
                         .map(|nid| nid.expect_enum_entry(store).unwrap())?
                         .value()
                         .into()
                 } else {
-                    return Err(error(nid, store));
+                    return Err(invalid_p_variable_nid(nid, store));
                 }
             }
         };


### PR DESCRIPTION
<!--
Thank you for improving `Cameleon`!

Please fill out the checklist before opening the PR.
-->

- [x] Check `test_all.sh` is passed.
- [x] Add `fix #{ISSUE_NUMBER}` if the corresponding issue exists.
- [x] Fill out `## Changelog` section. If the change is for only internal use, please write `None` to the section.

fix #230 

<!--
We collect a changelog from a PR description, so please write a brief description about the change in the following `Changelog` section.
-->
## Changelog
- Resolve `min`, `max`, and `inc` for `Converter` and `IntConverter` nodes from their referenced `pValue` nodes.
- Apply `FormulaFrom` when deriving converted bounds and increments.
- Forward default `Float` bounds/increments through `pValue` when the referenced node provides more specific constraints.
- Add GenApi tests covering converted bounds and increments.